### PR TITLE
fix(agents): limit merge commit title length to 72

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
@@ -43,6 +43,7 @@ import {
   GitPrError,
   GitPrErrorCode,
 } from '@/application/ports/output/services/git-pr-service.interface.js';
+import { truncateCommitTitle } from '@/infrastructure/services/git/pr-branding.js';
 import { parseCommitHash, parsePrUrl } from './merge-output-parser.js';
 import { runCiWatchFixLoop } from './ci-watch-fix-loop.js';
 import { getSettings } from '@/infrastructure/services/settings.service.js';
@@ -426,7 +427,7 @@ export function createMergeNode(deps: MergeNodeDeps) {
           // On MERGE_CONFLICT, falls back to agent-based merge for conflict resolution.
           log.info('Programmatic local squash merge (no agent needed)');
 
-          const commitMsg = `feat: squash merge ${branch} into ${baseBranch}`;
+          const commitMsg = truncateCommitTitle(`feat: squash merge ${branch} into ${baseBranch}`);
           try {
             await deps.localMergeSquash(
               state.repositoryPath,

--- a/packages/core/src/infrastructure/services/git/pr-branding.ts
+++ b/packages/core/src/infrastructure/services/git/pr-branding.ts
@@ -14,6 +14,9 @@ export const PR_BRANDING =
 /** The co-author trailer to include in commit messages. */
 export const COMMIT_CO_AUTHOR = 'Co-Authored-By: Shep Bot <shep-agent@users.noreply.github.com>';
 
+/** Maximum length for a commit title (first line), per the conventional-commits header rule. */
+export const MAX_COMMIT_TITLE_LENGTH = 72;
+
 /**
  * Pattern matching common AI-tool attribution footers that should be
  * replaced (e.g. "Generated with Claude Code", "Co-Authored-By: Claude").
@@ -74,4 +77,22 @@ export function applyCommitBranding(message: string): string {
   }
 
   return cleaned;
+}
+
+/**
+ * Truncate a commit title (first line) to at most `maxLength` characters,
+ * replacing the cut-off tail with an ellipsis so the result stays within
+ * the conventional-commits header limit.
+ *
+ * Titles at or under the limit are returned unchanged.
+ */
+export function truncateCommitTitle(
+  title: string,
+  maxLength: number = MAX_COMMIT_TITLE_LENGTH
+): string {
+  const limit = Number.isFinite(maxLength) ? Math.floor(maxLength) : MAX_COMMIT_TITLE_LENGTH;
+  if (limit <= 0) return '';
+  if (title.length <= limit) return title;
+  if (limit === 1) return '…';
+  return `${title.slice(0, limit - 1).trimEnd()}…`;
 }

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
@@ -424,6 +424,31 @@ describe('createMergeNode (agent-driven)', () => {
         true
       );
     });
+
+    it('should truncate the local squash merge commit title to 72 characters when branch names are long', async () => {
+      const longBranch =
+        'feat/some-very-long-descriptive-feature-branch-name-that-is-way-too-long-for-a-commit-title';
+      const longBranchDeps = baseDeps({
+        featureRepository: {
+          findById: vi.fn().mockResolvedValue({
+            id: 'feat-001',
+            lifecycle: 'Implementation',
+            branch: longBranch,
+          }),
+          update: vi.fn().mockResolvedValue(undefined),
+        } as any,
+      });
+      const node = createMergeNode(longBranchDeps);
+      const state = baseState({
+        approvalGates: { allowPrd: false, allowPlan: false, allowMerge: true },
+      });
+      await node(state);
+
+      const [, , , commitMessage] = (longBranchDeps.localMergeSquash as ReturnType<typeof vi.fn>)
+        .mock.calls[0];
+      expect(commitMessage.length).toBeLessThanOrEqual(72);
+      expect(commitMessage.endsWith('…')).toBe(true);
+    });
   });
 
   // --- Conditional push/PR logic ---

--- a/tests/unit/infrastructure/services/git/pr-branding.test.ts
+++ b/tests/unit/infrastructure/services/git/pr-branding.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   PR_BRANDING,
   COMMIT_CO_AUTHOR,
+  MAX_COMMIT_TITLE_LENGTH,
   applyPrBranding,
   applyCommitBranding,
+  truncateCommitTitle,
 } from '@/infrastructure/services/git/pr-branding.js';
 
 describe('PR_BRANDING', () => {
@@ -157,5 +159,35 @@ describe('applyCommitBranding', () => {
   it('should trim trailing whitespace before appending co-author', () => {
     const result = applyCommitBranding('feat(cli): add command   \n\n\n');
     expect(result).toBe(`feat(cli): add command\n\n${COMMIT_CO_AUTHOR}`);
+  });
+});
+
+describe('truncateCommitTitle', () => {
+  it('should leave short titles unchanged', () => {
+    const title = 'feat: squash merge feat/test into main';
+    expect(truncateCommitTitle(title)).toBe(title);
+  });
+
+  it('should not modify a title exactly at the max length', () => {
+    const title = `feat: ${'a'.repeat(MAX_COMMIT_TITLE_LENGTH - 6)}`;
+    expect(title.length).toBe(MAX_COMMIT_TITLE_LENGTH);
+    expect(truncateCommitTitle(title)).toBe(title);
+  });
+
+  it('should truncate titles longer than 72 characters with an ellipsis', () => {
+    const longBranch = 'feat/some-very-long-descriptive-feature-branch-name-that-is-too-long';
+    const title = `feat: squash merge ${longBranch} into main`;
+    expect(title.length).toBeGreaterThan(MAX_COMMIT_TITLE_LENGTH);
+
+    const result = truncateCommitTitle(title);
+    expect(result.length).toBe(MAX_COMMIT_TITLE_LENGTH);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.startsWith('feat: squash merge')).toBe(true);
+  });
+
+  it('should respect a custom max length', () => {
+    const result = truncateCommitTitle('0123456789', 5);
+    expect(result).toBe('0123…');
+    expect(result.length).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary

Local squash-merge commit titles are built from the feature and base branch names (`feat: squash merge <branch> into <baseBranch>`), so a long branch name could produce a commit title that violates the repo's 72-char conventional-commit subject limit.

Adds `truncateCommitTitle()` (+ `MAX_COMMIT_TITLE_LENGTH` constant) to `pr-branding.ts` and clamps the generated title before it's used for the local squash-merge commit, and in the conflict-resolution fallback prompt that reuses the same title.

## Changes

- `packages/core/src/infrastructure/services/git/pr-branding.ts` — new `truncateCommitTitle()` helper
- `packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts` — clamp the generated squash-merge commit title
- Unit tests for both the helper and the merge-node integration (TDD red → green)

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (10538 passed)
- [x] `pnpm build`