### PR TITLE
fix(agents): resume implementation after a merge review rejection

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
@@ -297,13 +297,13 @@ export function createFeatureAgentGraph(
         .addNode('merge', createMergeNode(mergeNodeDeps))
         .addNode('extract_memory', createExtractMemoryNode({ executor, ...deps.extractMemoryDeps }))
         .addEdge('implement', 'merge')
-        .addConditionalEdges('merge', routeReexecution('merge', 'extract_memory'))
+        .addConditionalEdges('merge', routeReexecution('implement', 'extract_memory'))
         .addEdge('extract_memory', END);
     } else {
       graph
         .addNode('merge', createMergeNode(mergeNodeDeps))
         .addEdge('implement', 'merge')
-        .addConditionalEdges('merge', routeReexecution('merge', END));
+        .addConditionalEdges('merge', routeReexecution('implement', END));
     }
   } else {
     graph.addEdge('implement', END);

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/fast-implement.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/fast-implement.node.ts
@@ -44,9 +44,11 @@ export function createFastImplementNode(executor: IAgentExecutor, selectMemory?:
     reportNodeStart('fast-implement');
     await updateNodeLifecycle('fast-implement');
 
-    // Skip if already completed (resume from error path)
+    // Skip if already completed (resume from error path). Not on a merge
+    // rejection resume, though — _needsReexecution means the user rejected
+    // the merge and gave feedback that this phase must still address.
     const completedPhases = getCompletedPhases(state.specDir);
-    if (completedPhases.includes('fast-implement')) {
+    if (completedPhases.includes('fast-implement') && !state._needsReexecution) {
       log.info('Phase already completed, skipping execution');
       return {
         currentNode: 'fast-implement',

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/implement.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/implement.node.ts
@@ -24,6 +24,7 @@ import {
   getCompletedPhases,
   markPhaseComplete,
   applyMemorySelection,
+  getPhaseRejectionFeedback,
   type MemorySelector,
 } from './node-helpers.js';
 import { reportNodeStart } from '../heartbeat.js';
@@ -41,6 +42,7 @@ import {
 } from '../sdlc-board-context.js';
 import {
   buildImplementPhasePrompt,
+  buildImplementRejectionFixPrompt,
   type PlanPhase,
   type PlanYaml,
   type PhaseTask,
@@ -141,6 +143,40 @@ export function createImplementNode(executor: IAgentExecutor, selectMemory?: Mem
 
       // --- Check for completed phases (skip on resume) ---
       const completedPhaseIds = getCompletedPhases(state.specDir);
+
+      // --- Merge-rejection redo: implementation already fully completed once,
+      // but the user rejected the merge with feedback. Every phase below would
+      // just skip (already in completedPhaseIds), silently discarding the
+      // feedback. Run one focused pass to address it instead. ---
+      if (state._needsReexecution) {
+        const specContent = readSpecFile(state.specDir, 'spec.yaml');
+        const rejectionSection = getPhaseRejectionFeedback(specContent ?? '', 'merge');
+        if (rejectionSection) {
+          log.info('Addressing merge rejection feedback');
+          const options = buildExecutorOptions(state, undefined, 'implement');
+          const prompt = buildImplementRejectionFixPrompt(stateForPrompt, rejectionSection);
+          await updatePhasePrompt(implementTimingId, prompt);
+          const result = await retryExecute(executor, prompt, options, { logger: log });
+          const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+          log.info(`Rejection feedback addressed (${result.result.length} chars, ${elapsed}s)`);
+          await recordPhaseEnd(implementTimingId, Date.now() - startTime, {
+            inputTokens: result.usage?.inputTokens,
+            outputTokens: result.usage?.outputTokens,
+            costUsd: result.usage?.costUsd,
+            numTurns: result.usage?.numTurns,
+            durationApiMs: result.usage?.durationApiMs,
+            exitCode: 'success',
+          });
+          return {
+            currentNode: 'implement',
+            messages: [`[implement] Addressed merge rejection feedback (${elapsed}s)`],
+            _needsReexecution: false,
+          };
+        }
+        log.info(
+          '_needsReexecution set but no merge rejection feedback found in spec.yaml — continuing normally'
+        );
+      }
 
       // --- Seed SDLC board: idempotent upsert of all phases as Tasks
       //     and their tasks.yaml entries as SubTasks (best-effort). ---

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -375,6 +375,49 @@ export function markPhaseComplete(specDir: string, phaseId: string, log?: NodeLo
 }
 
 /**
+ * Extract and format the latest rejection feedback for a given phase
+ * (e.g. 'merge') from spec.yaml content. Returns a markdown section
+ * instructing the agent to address it, or '' when there is none.
+ *
+ * Shared by every prompt builder that needs to surface rejection feedback
+ * (merge, fast-implement, implement) so the wording and iteration/older-
+ * feedback handling stay in sync across them.
+ */
+export function getPhaseRejectionFeedback(specContent: string, phase: string): string {
+  try {
+    const specData = yaml.load(specContent) as Record<string, unknown> | null;
+    const rejectionFeedback = specData?.rejectionFeedback as
+      | { iteration: number; message: string; phase?: string; timestamp: string }[]
+      | undefined;
+    if (!rejectionFeedback?.length) return '';
+
+    const matching = rejectionFeedback.filter((e) => e.phase === phase);
+    if (matching.length === 0) return '';
+
+    const latest = matching[matching.length - 1];
+    const older = matching.slice(0, -1);
+    const olderSection =
+      older.length > 0
+        ? `\n### Earlier feedback (for context only)\n${older.map((e) => `- Iteration ${e.iteration}: ${e.message}`).join('\n')}\n`
+        : '';
+
+    return `
+## ⚠️ CRITICAL — User Rejection Feedback (MUST ADDRESS)
+
+**YOUR PRIMARY TASK: The user rejected the previous result and gave this feedback. You MUST act on it:**
+
+> ${latest.message}
+
+(Iteration ${latest.iteration}, ${latest.timestamp})
+
+Do NOT just record this feedback — you must actually make the changes the user requested.
+${olderSection}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Write a spec file atomically using temp-file-then-rename pattern.
  * Prevents corruption on crash mid-write.
  */

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/fast-implement.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/fast-implement.prompt.ts
@@ -12,7 +12,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
-import { readSpecFile } from '../node-helpers.js';
+import { readSpecFile, getPhaseRejectionFeedback } from '../node-helpers.js';
 import { buildProjectMemorySection } from './project-memory-section.js';
 import type { FeatureAgentState } from '../../state.js';
 import { COMMIT_CO_AUTHOR } from '../../../../git/pr-branding.js';
@@ -111,44 +111,13 @@ function extractUserQuery(specDir: string): string {
 }
 
 /**
- * Extract rejection feedback from spec.yaml for merge-phase rejections.
+ * Extract merge-phase rejection feedback from spec.yaml.
  * Returns a formatted prompt section if feedback exists, empty string otherwise.
  */
 function getRejectionFeedback(specDir: string): string {
-  try {
-    const specContent = readSpecFile(specDir, 'spec.yaml');
-    if (!specContent) return '';
-
-    const specData = yaml.load(specContent) as Record<string, unknown> | null;
-    const rejectionFeedback = specData?.rejectionFeedback as
-      | { iteration: number; message: string; phase?: string; timestamp: string }[]
-      | undefined;
-    if (rejectionFeedback && rejectionFeedback.length > 0) {
-      const mergeRejections = rejectionFeedback.filter((e) => e.phase === 'merge');
-      if (mergeRejections.length > 0) {
-        const latest = mergeRejections[mergeRejections.length - 1];
-        const older = mergeRejections.slice(0, -1);
-        const olderSection =
-          older.length > 0
-            ? `\n### Earlier feedback (for context only)\n${older.map((e) => `- Iteration ${e.iteration}: ${e.message}`).join('\n')}\n`
-            : '';
-        return `
-## CRITICAL — User Rejection Feedback (MUST ADDRESS)
-
-**YOUR PRIMARY TASK: The user rejected the previous result and gave this feedback. You MUST act on it:**
-
-> ${latest.message}
-
-(Iteration ${latest.iteration}, ${latest.timestamp})
-
-Do NOT just record this feedback — you must actually make the changes the user requested.
-${olderSection}`;
-      }
-    }
-  } catch {
-    // Continue without rejection feedback
-  }
-  return '';
+  const specContent = readSpecFile(specDir, 'spec.yaml');
+  if (!specContent) return '';
+  return getPhaseRejectionFeedback(specContent, 'merge');
 }
 
 /**

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/implement.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/implement.prompt.ts
@@ -147,3 +147,63 @@ ${cwd}
 - Do NOT skip writing tests for tasks that have TDD guidance
 - Keep changes focused and minimal — avoid unnecessary refactoring beyond what the tasks specify`;
 }
+
+/**
+ * Build the prompt used when re-entering `implement` after the user rejected
+ * the merge with feedback. All phases are already implemented at this point,
+ * so this is a single focused pass to address the feedback rather than a
+ * replay of the full per-phase plan.
+ */
+export function buildImplementRejectionFixPrompt(
+  state: FeatureAgentState,
+  rejectionSection: string
+): string {
+  const specContent = readSpecFile(state.specDir, 'spec.yaml');
+  const researchContent = readSpecFile(state.specDir, 'research.yaml');
+  const planContent = readSpecFile(state.specDir, 'plan.yaml');
+  const cwd = state.worktreePath || state.repositoryPath;
+
+  return `You are a senior software engineer performing autonomous implementation.
+Implementation of this feature previously completed, but the user rejected it at the merge review stage.
+${rejectionSection}
+${buildProjectMemorySection(state)}## Feature Specification
+
+\`\`\`yaml
+${specContent}
+\`\`\`
+
+## Research Decisions
+
+\`\`\`yaml
+${researchContent}
+\`\`\`
+
+## Implementation Plan
+
+\`\`\`yaml
+${planContent}
+\`\`\`
+
+## Instructions
+
+1. Address the rejection feedback above by modifying the existing implementation
+2. Follow existing codebase conventions for file placement, naming patterns, and architecture layers
+3. Run the test suite, linter, and type checker — all must pass
+   - Discover the correct commands by inspecting package.json or the project's build tooling
+   - Fix any issues before finishing
+4. Commit your work with descriptive conventional commit messages and include the Shep Bot co-author trailer:
+   - e.g. \`git commit -m "fix(scope): description" -m "" -m "${COMMIT_CO_AUTHOR}"\`
+   - Do NOT include any other Co-Authored-By trailer (e.g. Claude) — only the Shep Bot trailer above
+   - It is CRITICAL that all changes are committed before this phase ends
+
+## Working Directory
+
+${cwd}
+
+## Constraints
+
+- Address ONLY the rejection feedback above — do not work ahead or make unrelated changes
+- Follow existing codebase conventions and architecture patterns
+- Do NOT modify any spec YAML files (spec.yaml, research.yaml, plan.yaml, tasks.yaml, feature.yaml)
+- Keep changes focused and minimal — avoid unnecessary refactoring beyond what the feedback requires`;
+}

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -9,50 +9,11 @@
  * GitPrService.mergePr() and GitPrService.localMergeSquash() — not via agent prompts.
  */
 
-import yaml from 'js-yaml';
 import { EvidenceType, type Evidence } from '@/domain/generated/output.js';
-import { readSpecFile, buildResumeContext } from '../node-helpers.js';
+import { readSpecFile, buildResumeContext, getPhaseRejectionFeedback } from '../node-helpers.js';
 import { buildProjectMemorySection, renderProjectMemoryBlock } from './project-memory-section.js';
 import type { FeatureAgentState } from '../../state.js';
 import { PR_BRANDING, COMMIT_CO_AUTHOR } from './pr-branding.js';
-
-/**
- * Extract merge-phase rejection feedback from spec.yaml.
- */
-function getMergeRejectionFeedback(specContent: string): string {
-  try {
-    const specData = yaml.load(specContent) as Record<string, unknown> | null;
-    const rejectionFeedback = specData?.rejectionFeedback as
-      | { iteration: number; message: string; phase?: string; timestamp: string }[]
-      | undefined;
-    if (rejectionFeedback && rejectionFeedback.length > 0) {
-      const mergeRejections = rejectionFeedback.filter((e) => e.phase === 'merge');
-      if (mergeRejections.length > 0) {
-        const latest = mergeRejections[mergeRejections.length - 1];
-        const older = mergeRejections.slice(0, -1);
-        const olderSection =
-          older.length > 0
-            ? `\n### Earlier feedback (for context only)\n${older.map((e) => `- Iteration ${e.iteration}: ${e.message}`).join('\n')}\n`
-            : '';
-        return `
-## ⚠️ CRITICAL — User Rejection Feedback (MUST ADDRESS)
-
-**YOUR PRIMARY TASK: The user rejected the previous result and gave this feedback. You MUST act on it:**
-
-> ${latest.message}
-
-(Iteration ${latest.iteration}, ${latest.timestamp})
-
-Do NOT just record this feedback — you must actually make the changes the user requested.
-${olderSection}
-`;
-      }
-    }
-  } catch {
-    // Continue without rejection feedback
-  }
-  return '';
-}
 
 /**
  * Parse a GitHub remote URL (HTTPS or SSH) into owner/repo.
@@ -144,7 +105,7 @@ export function buildCommitPushPrPrompt(
   const specContent = readSpecFile(state.specDir, 'spec.yaml');
   const cwd = state.worktreePath || state.repositoryPath;
   const shouldPush = state.push || state.openPr;
-  const rejectionSection = getMergeRejectionFeedback(specContent);
+  const rejectionSection = getPhaseRejectionFeedback(specContent, 'merge');
   // Only include evidence in the PR body when commitEvidence is enabled
   const evidenceSection = state.evidence?.length
     ? formatEvidenceSection(state.evidence, branch, repoUrl)

--- a/tests/integration/infrastructure/services/agents/graph-state-transitions/reject-feedback-propagation.test.ts
+++ b/tests/integration/infrastructure/services/agents/graph-state-transitions/reject-feedback-propagation.test.ts
@@ -316,12 +316,13 @@ describe('Graph State Transitions › Reject Feedback Propagation', () => {
         expect(allFeedback[i].phase).toBe('merge');
         expect(allFeedback[i].message).toBe(messages[i]);
 
-        // 3. Reject — re-executes merge, interrupts again
+        // 3. Reject — routes back through implement (addresses the feedback),
+        // then re-runs merge's commit/push/PR call, interrupts again
         const result = await ctx.graph.invoke(rejectCommand(messages[i]), config);
         expectInterruptAt(result, 'merge');
 
-        // 4. Call count: initial(9) + rejections(i+1)
-        expect(ctx.executor.callCount).toBe(10 + i);
+        // 4. Call count: initial(9) + 2 calls per rejection (implement redo + merge-commit)
+        expect(ctx.executor.callCount).toBe(9 + 2 * (i + 1));
 
         // 5. Verify the merge re-execution prompt contains merge-specific feedback
         const reexecPrompt = ctx.executor.prompts[ctx.executor.prompts.length - 1];
@@ -339,8 +340,8 @@ describe('Graph State Transitions › Reject Feedback Propagation', () => {
       expect(finalFeedback).toHaveLength(10);
       expect(finalFeedback.every((f) => f.phase === 'merge')).toBe(true);
 
-      // Call count: initial(9) + 10 re-execs = 19
-      expect(ctx.executor.callCount).toBe(19);
+      // Call count: initial(9) + 10 rejections * 2 calls each = 29
+      expect(ctx.executor.callCount).toBe(29);
 
       // Approve and complete
       const rApprove = await ctx.graph.invoke(approveCommand(), config);
@@ -448,7 +449,9 @@ describe('Graph State Transitions › Reject Feedback Propagation', () => {
 
         const result = await ctx.graph.invoke(rejectCommand(msg), config);
         expectInterruptAt(result, 'merge');
-        expect(ctx.executor.callCount).toBe(30 + i);
+        // Each merge rejection now costs 2 calls: implement (addresses the
+        // feedback) + merge's commit/push/PR re-run.
+        expect(ctx.executor.callCount).toBe(29 + 2 * (i + 1));
 
         // Verify merge feedback section in prompt
         const prompt = ctx.executor.prompts[ctx.executor.prompts.length - 1];
@@ -481,7 +484,8 @@ describe('Graph State Transitions › Reject Feedback Propagation', () => {
       expect(finalFeedback[29].iteration).toBe(30);
 
       // Approve merge — graph completes
-      expect(ctx.executor.callCount).toBe(39);
+      // 29 before this loop + 10 rejections * 2 calls each = 49
+      expect(ctx.executor.callCount).toBe(49);
       const rApproveMerge = await ctx.graph.invoke(approveCommand(), config);
       expectNoInterrupts(rApproveMerge);
     });

--- a/tests/unit/infrastructure/services/agents/langgraph/feature-agent-graph.test.ts
+++ b/tests/unit/infrastructure/services/agents/langgraph/feature-agent-graph.test.ts
@@ -518,6 +518,111 @@ describe('createFeatureAgentGraph', () => {
     });
   });
 
+  describe('merge rejection routes back to implement', () => {
+    it('re-invokes implement (not a merge self-loop) and surfaces the rejection feedback', async () => {
+      const MOCK_SPEC_YAML_WITH_REJECTION = `${MOCK_SPEC_YAML}rejectionFeedback:
+  - iteration: 1
+    message: "Please also update the changelog before merging"
+    phase: merge
+    timestamp: "2026-01-01T00:00:00.000Z"
+`;
+
+      let feature: Record<string, unknown> = {
+        id: 'feat-merge-reject',
+        lifecycle: 'Implementation',
+      };
+      const featureRepository = {
+        findById: vi.fn(async () => ({ ...feature }) as never),
+        update: vi.fn(async (f: Record<string, unknown>) => {
+          feature = { ...feature, ...f };
+          return feature as never;
+        }),
+      };
+
+      setupSpecFileMocks();
+
+      const compiled = createFeatureAgentGraph(
+        {
+          executor: mockExecutor,
+          mergeNodeDeps: {
+            selectMemory: undefined,
+            getDiffSummary: vi
+              .fn()
+              .mockResolvedValue({ filesChanged: 1, additions: 1, deletions: 0, commitCount: 1 }),
+            hasRemote: vi.fn().mockResolvedValue(false),
+            getDefaultBranch: vi.fn().mockResolvedValue('main'),
+            featureRepository,
+            localMergeSquash: vi.fn(),
+            verifyMerge: vi.fn().mockResolvedValue(true),
+            revParse: vi.fn().mockResolvedValue('abc1234'),
+            gitPrService: {} as never,
+            cleanupFeatureWorktreeUseCase: { execute: vi.fn() },
+          },
+        },
+        checkpointer
+      );
+      const config = { configurable: { thread_id: 'merge-reject-thread' } };
+
+      // First pass: analyze..implement run, then merge's own commit-only
+      // agent call, then interrupt for merge approval.
+      const first = await compiled.invoke(
+        {
+          featureId: 'feat-merge-reject',
+          repositoryPath: '/test/repo',
+          worktreePath: '/test/repo',
+          specDir: '/test/specs/001-merge-reject',
+          enableEvidence: false,
+          commitEvidence: false,
+          approvalGates: { allowPrd: true, allowPlan: true, allowMerge: false },
+        },
+        config
+      );
+      const firstInterrupt = (first as Record<string, unknown>).__interrupt__ as
+        | { value: { node: string } }[]
+        | undefined;
+      expect(firstInterrupt?.[0]?.value?.node).toBe('merge');
+
+      const callsBeforeResume = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls
+        .length;
+
+      // Simulate RejectAgentRunUseCase having already appended the
+      // rejection feedback to spec.yaml before the worker resumes.
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (typeof path === 'string') {
+          if (path.endsWith('spec.yaml')) return MOCK_SPEC_YAML_WITH_REJECTION;
+          if (path.endsWith('research.yaml')) return MOCK_RESEARCH_YAML;
+          if (path.endsWith('plan.yaml')) return MOCK_PLAN_YAML;
+          if (path.endsWith('tasks.yaml')) return MOCK_TASKS_YAML;
+          if (path.endsWith('feature.yaml')) return MOCK_FEATURE_YAML;
+        }
+        return 'name: test\ndescription: A test feature';
+      });
+
+      const { Command } = await import('@langchain/langgraph');
+      await compiled.invoke(
+        new Command({
+          resume: { rejected: true, feedback: 'Please also update the changelog before merging' },
+          update: {
+            _approvalAction: 'rejected',
+            _rejectionFeedback: 'Please also update the changelog before merging',
+          },
+        }),
+        config
+      );
+
+      // The very next executor call after resume must be the implement
+      // redo pass carrying the rejection feedback — not another merge
+      // commit/push/PR call that never mentions it.
+      const callsAfterResume = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls.slice(
+        callsBeforeResume
+      );
+      expect(callsAfterResume.length).toBeGreaterThan(0);
+      const [redoPrompt] = callsAfterResume[0];
+      expect(redoPrompt).toContain('Please also update the changelog before merging');
+      expect(redoPrompt).toContain('User Rejection Feedback');
+    });
+  });
+
   describe('state persistence with checkpointer', () => {
     it('should persist state across invocations via checkpointer', async () => {
       setupSpecFileMocks();

--- a/tests/unit/infrastructure/services/agents/langgraph/nodes/fast-implement.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/langgraph/nodes/fast-implement.node.test.ts
@@ -363,6 +363,28 @@ describe('buildFastImplementPrompt', () => {
     expect(prompt).toContain('...(truncated)');
   });
 
+  it('should include merge rejection feedback in the prompt when present in spec.yaml', () => {
+    setupFileMocks({
+      specYaml: `name: quick-fix
+userQuery: >
+  Fix the typo in the README
+summary: Fix typo
+phase: Analysis
+rejectionFeedback:
+  - iteration: 1
+    message: "Please also update the changelog"
+    phase: merge
+    timestamp: "2026-01-01T00:00:00.000Z"
+`,
+    });
+    const state = createMockState();
+
+    const prompt = buildFastImplementPrompt(state);
+
+    expect(prompt).toContain('User Rejection Feedback');
+    expect(prompt).toContain('Please also update the changelog');
+  });
+
   it('should handle missing spec.yaml gracefully', () => {
     setupFileMocks({ specYaml: null });
     const state = createMockState();
@@ -531,6 +553,20 @@ describe('createFastImplementNode', () => {
     expect(mockExecutor.execute).not.toHaveBeenCalled();
     expect(result.currentNode).toBe('fast-implement');
     expect(result.messages![0]).toContain('already completed');
+  });
+
+  it('should re-execute despite an already-completed phase when _needsReexecution is true (merge rejection resume)', async () => {
+    setupFileMocks();
+    mockGetCompletedPhases.mockReturnValue(['fast-implement']);
+    const node = createFastImplementNode(mockExecutor);
+    const state = createMockState({ _needsReexecution: true });
+
+    const result = await node(state);
+
+    // Must NOT take the "already completed — skipping" shortcut.
+    expect(mockExecutor.execute).toHaveBeenCalled();
+    expect(result.currentNode).toBe('fast-implement');
+    expect(result._needsReexecution).toBe(false);
   });
 
   it('should call markPhaseComplete after successful execution', async () => {

--- a/tests/unit/infrastructure/services/agents/langgraph/nodes/implement.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/langgraph/nodes/implement.node.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Implement Node — Merge-Rejection Redo Tests
+ *
+ * When the user rejects the merge with feedback, the graph routes back to
+ * `implement`. Every phase is already in completedPhases at that point, so
+ * without special handling the normal per-phase loop would silently skip
+ * everything and never call the executor — the feedback would be ignored.
+ *
+ * Covers the redo branch that runs one focused pass to address the
+ * feedback instead, and confirms it is bypassed on a normal first run.
+ *
+ * TDD Phase: RED → GREEN
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IAgentExecutor } from '@/application/ports/output/agents/agent-executor.interface.js';
+import { SecurityMode } from '@/domain/generated/output.js';
+import type { AgentType } from '@/domain/generated/output.js';
+import type { FeatureAgentState } from '@/infrastructure/services/agents/feature-agent/state.js';
+
+// ─── Mocks ──────────────────────────────────────────────────────────
+
+const { mockReadFileSync, mockWriteFileSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: { ...actual, readFileSync: mockReadFileSync, writeFileSync: mockWriteFileSync },
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+  };
+});
+
+const { mockGetCompletedPhases, mockMarkPhaseComplete } = vi.hoisted(() => ({
+  mockGetCompletedPhases: vi.fn().mockReturnValue([]),
+  mockMarkPhaseComplete: vi.fn(),
+}));
+
+vi.mock(
+  '@/infrastructure/services/agents/feature-agent/nodes/node-helpers.js',
+  async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return {
+      ...actual,
+      getCompletedPhases: mockGetCompletedPhases,
+      markPhaseComplete: mockMarkPhaseComplete,
+    };
+  }
+);
+
+vi.mock('@/infrastructure/services/agents/feature-agent/heartbeat.js', () => ({
+  reportNodeStart: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/services/agents/feature-agent/lifecycle-context.js', () => ({
+  updateNodeLifecycle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/infrastructure/services/agents/feature-agent/phase-timing-context.js', () => ({
+  recordPhaseStart: vi.fn().mockResolvedValue('timing-id'),
+  recordPhaseEnd: vi.fn().mockResolvedValue(undefined),
+  recordApprovalWaitStart: vi.fn().mockResolvedValue(undefined),
+  updatePhasePrompt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/infrastructure/services/settings.service.js', () => ({
+  hasSettings: vi.fn().mockReturnValue(true),
+  getSettings: vi.fn().mockReturnValue({
+    workflow: { enableEvidence: false, commitEvidence: false },
+  }),
+}));
+
+import { createImplementNode } from '@/infrastructure/services/agents/feature-agent/nodes/implement.node.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+const MOCK_SPEC_YAML_NO_FEEDBACK = `name: test
+summary: Test feature
+`;
+
+const MOCK_SPEC_YAML_WITH_MERGE_REJECTION = `name: test
+summary: Test feature
+rejectionFeedback:
+  - iteration: 1
+    message: "Please also update the changelog before merging"
+    phase: merge
+    timestamp: "2026-01-01T00:00:00.000Z"
+`;
+
+const MOCK_RESEARCH_YAML = `name: test\nsummary: research\ncontent: research content\ndecisions: []\n`;
+
+const MOCK_PLAN_YAML = `content: Plan content
+phases:
+  - id: phase-1
+    name: 'Test Phase'
+    parallel: false
+    taskIds:
+      - task-1
+`;
+
+const MOCK_TASKS_YAML = `name: test
+tasks:
+  - id: task-1
+    title: Test Task
+    description: A test task
+    state: Todo
+    phaseId: phase-1
+    dependencies: []
+    acceptanceCriteria:
+      - It works
+    tdd: null
+    estimatedEffort: 15min
+`;
+
+function setupFileMocks(specYaml: string): void {
+  mockReadFileSync.mockImplementation((path: string) => {
+    if (typeof path === 'string') {
+      if (path.endsWith('spec.yaml')) return specYaml;
+      if (path.endsWith('research.yaml')) return MOCK_RESEARCH_YAML;
+      if (path.endsWith('plan.yaml')) return MOCK_PLAN_YAML;
+      if (path.endsWith('tasks.yaml')) return MOCK_TASKS_YAML;
+      if (path.endsWith('feature.yaml')) return 'feature:\n  id: test\nstatus: {}\n';
+    }
+    throw new Error(`ENOENT: no such file: ${path}`);
+  });
+}
+
+function createMockState(overrides?: Partial<FeatureAgentState>): FeatureAgentState {
+  return {
+    featureId: 'feat-123',
+    repositoryPath: '/test/repo',
+    specDir: '/test/specs/001-test',
+    worktreePath: '/test/worktree',
+    currentNode: '',
+    error: null,
+    approvalGates: undefined,
+    messages: [],
+    validationRetries: 0,
+    lastValidationTarget: '',
+    lastValidationErrors: [],
+    _approvalAction: null,
+    _rejectionFeedback: null,
+    _needsReexecution: false,
+    prUrl: null,
+    prNumber: null,
+    commitHash: null,
+    ciStatus: null,
+    merged: false,
+    projectMemory: undefined,
+    push: false,
+    openPr: false,
+    ciFixAttempts: 0,
+    ciFixHistory: [],
+    ciFixStatus: 'idle',
+    evidence: [],
+    evidenceRetries: 0,
+    model: undefined,
+    resumeReason: undefined,
+    forkAndPr: false,
+    commitSpecs: true,
+    ciWatchEnabled: true,
+    enableEvidence: false,
+    commitEvidence: false,
+    securityMode: SecurityMode.Disabled,
+    securityActionDispositions: {},
+    mcpConfigPath: undefined,
+    iterationCount: 0,
+    maxIterations: 10,
+    feedbackHistory: [],
+    explorationStatus: undefined,
+    ...overrides,
+  };
+}
+
+function createMockExecutor(): IAgentExecutor {
+  return {
+    agentType: 'claude-code' as AgentType,
+    execute: vi.fn().mockResolvedValue({ result: 'Mock executor result' }),
+    executeStream: vi.fn(),
+    supportsFeature: vi.fn().mockReturnValue(false),
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('createImplementNode — merge-rejection redo', () => {
+  let mockExecutor: IAgentExecutor;
+
+  beforeEach(() => {
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    mockGetCompletedPhases.mockReset();
+    mockMarkPhaseComplete.mockReset();
+    mockExecutor = createMockExecutor();
+  });
+
+  it('runs one focused executor pass addressing the feedback instead of skipping every completed phase', async () => {
+    setupFileMocks(MOCK_SPEC_YAML_WITH_MERGE_REJECTION);
+    // All phases already completed from the initial run.
+    mockGetCompletedPhases.mockReturnValue(['phase-1']);
+    const node = createImplementNode(mockExecutor);
+    const state = createMockState({ _needsReexecution: true });
+
+    const result = await node(state);
+
+    expect(mockExecutor.execute).toHaveBeenCalledTimes(1);
+    const [prompt] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(prompt).toContain('Please also update the changelog before merging');
+    expect(prompt).toContain('User Rejection Feedback');
+    expect(result.currentNode).toBe('implement');
+    expect(result._needsReexecution).toBe(false);
+  });
+
+  it('falls through to the normal phase walk when _needsReexecution is true but no feedback is found', async () => {
+    setupFileMocks(MOCK_SPEC_YAML_NO_FEEDBACK);
+    mockGetCompletedPhases.mockReturnValue(['phase-1']);
+    const node = createImplementNode(mockExecutor);
+    const state = createMockState({ _needsReexecution: true });
+
+    const result = await node(state);
+
+    // No feedback to act on — the (already-completed) phase loop runs and
+    // skips, so the executor is never called.
+    expect(mockExecutor.execute).not.toHaveBeenCalled();
+    expect(result.currentNode).toBe('implement');
+  });
+
+  it('does not take the redo branch on a normal first run', async () => {
+    setupFileMocks(MOCK_SPEC_YAML_WITH_MERGE_REJECTION);
+    mockGetCompletedPhases.mockReturnValue([]);
+    const node = createImplementNode(mockExecutor);
+    const state = createMockState({ _needsReexecution: false });
+
+    const result = await node(state);
+
+    // Normal phase loop executes phase-1 via the per-phase prompt, not the
+    // rejection-fix prompt.
+    expect(mockExecutor.execute).toHaveBeenCalledTimes(1);
+    const [prompt] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(prompt).not.toContain('User Rejection Feedback');
+    expect(prompt).toContain('Test Task');
+    expect(result.currentNode).toBe('implement');
+  });
+});


### PR DESCRIPTION
## Summary

Rejecting the merge review with feedback previously never routed the agent back to implementation — the user's feedback was recorded to `spec.yaml` but never actually acted on.

Two root causes:

- **Wrong graph routing**: `feature-agent-graph.ts` routed a rejected merge back to the `merge` node itself (a self-loop) instead of to `implement`, unlike the fast-mode graph, which already correctly hands off to `fast-implement`.
- **Silent no-op on re-entry**: even fast-mode's "correct" routing to `fast-implement` was neutralized because that node (and `implement`) skip re-execution once a phase is already marked complete in `feature.yaml` — which it always is by the time merge review is reached.

### Changes

- Route merge rejection to `implement` instead of looping on `merge`, matching the fast graph's existing pattern
- Let `implement`/`fast-implement` re-run when `_needsReexecution` is set from a rejection, instead of always skipping already-completed phases
- Add a focused "address rejection feedback" pass in `implement` so a full re-walk of every already-implemented phase isn't needed
- Extract the duplicated rejection-feedback prompt section (previously copy-pasted across `merge-prompts.ts` and `fast-implement.prompt.ts`) into one shared `getPhaseRejectionFeedback` helper

## Test plan

- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (10,539 tests)
- [x] `pnpm test:int` (1,566 tests, including an updated end-to-end `reject-feedback-propagation.test.ts` covering 10 merge rejection iterations)
- [x] `pnpm build`
- [x] New unit tests for the `implement`/`fast-implement` redo-branch behavior, and a new full-graph integration test asserting merge rejection routes through `implement` with the feedback in the prompt