### PR TITLE
fix(agents): create PRs on the upstream repo when a fork is detected

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -442,7 +442,7 @@ shep ui [--port] [--no-open]      # Start web UI in foreground
 shep feat new <description>       # Create a new feature
   --repo <path>                   #   Target repository
   --push                          #   Push branch on completion
-  --pr                            #   Open PR on completion
+  --pr                            #   Open PR on completion (auto-targets the upstream repo when a fork/upstream is detected; otherwise origin)
   --allow-prd                     #   Auto-approve PRD phase
   --allow-plan                    #   Auto-approve planning phase
   --allow-merge                   #   Auto-approve merge phase

--- a/packages/core/src/application/services/pr-target-resolution.ts
+++ b/packages/core/src/application/services/pr-target-resolution.ts
@@ -1,0 +1,95 @@
+/**
+ * PR-target resolution for the feature-agent merge step.
+ *
+ * Pure, total, non-throwing mapping (ADR-001): decides whether a pull request
+ * should be created on the upstream repository (fork workflow) or on the
+ * origin repository (default). All I/O (git remotes, gh fork-parent lookup)
+ * stays in infrastructure; this module only maps injected values.
+ *
+ * Detection strategy (ADR-003, most-conservative-wins):
+ *  1. Primary: explicit `upstream` git remote with a parseable GitHub URL.
+ *  2. Secondary: GitHub fork-parent info (when the primary signal is absent).
+ *  3. Fallback: any absence/ambiguity -> null (current origin behavior).
+ */
+
+export interface PrTarget {
+  /** Where the PR is created, e.g. "shep-ai/shep". */
+  targetRepo: string;
+  /** Base branch on the target repository, e.g. "main". */
+  baseBranch: string;
+  /** Owner-qualified head ref, e.g. "kevinnguyenhoang91:fix/pr_upstream". */
+  headRef: string;
+}
+
+export interface RemoteInfo {
+  name: string;
+  url: string;
+}
+
+export interface ForkParentInfo {
+  owner: string;
+  repo: string;
+  /** Default branch of the upstream (parent) repository. */
+  defaultBranch: string;
+}
+
+export interface PrTargetInputs {
+  remotes: RemoteInfo[];
+  /** null when the gh lookup is absent or failed (secondary signal unavailable). */
+  forkParent: ForkParentInfo | null;
+  /** Feature branch (head). */
+  branch: string;
+  /** Base to use when no upstream default branch is known. */
+  fallbackBaseBranch: string;
+}
+
+/** Extract `owner/repo` from an SSH or HTTPS GitHub remote URL, else null. */
+export function parseGithubOwnerRepo(url: string): { owner: string; repo: string } | null {
+  const ssh = /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i.exec(url.trim());
+  if (ssh) return { owner: ssh[1], repo: ssh[2] };
+  const https = /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i.exec(url.trim());
+  if (https) return { owner: https[1], repo: https[2] };
+  return null;
+}
+
+/**
+ * Resolve the PR target from injected inputs.
+ * Returns null when the repo should keep current behavior (PR on origin).
+ */
+export function resolvePrTarget(inputs: PrTargetInputs): PrTarget | null {
+  const origin = inputs.remotes.find((r) => r.name === 'origin');
+  const originOwnerRepo = origin ? parseGithubOwnerRepo(origin.url) : null;
+  // Head qualification requires a parseable origin (the user's fork).
+  if (!originOwnerRepo) return null;
+  const headRef = `${originOwnerRepo.owner}:${inputs.branch}`;
+
+  // 1. Primary signal: explicit `upstream` remote.
+  const upstream = inputs.remotes.find((r) => r.name === 'upstream');
+  if (upstream && upstream.url.trim() !== '') {
+    const upstreamOwnerRepo = parseGithubOwnerRepo(upstream.url);
+    if (!upstreamOwnerRepo) return null; // ambiguity -> fallback (REQ-003)
+    // Use forkParent's default branch only when it describes this upstream.
+    const baseBranch =
+      inputs.forkParent?.owner === upstreamOwnerRepo.owner &&
+      inputs.forkParent.repo === upstreamOwnerRepo.repo
+        ? inputs.forkParent.defaultBranch
+        : inputs.fallbackBaseBranch;
+    return {
+      targetRepo: `${upstreamOwnerRepo.owner}/${upstreamOwnerRepo.repo}`,
+      baseBranch,
+      headRef,
+    };
+  }
+
+  // 2. Secondary signal: GitHub fork-parent (no upstream remote configured).
+  if (inputs.forkParent) {
+    return {
+      targetRepo: `${inputs.forkParent.owner}/${inputs.forkParent.repo}`,
+      baseBranch: inputs.forkParent.defaultBranch,
+      headRef,
+    };
+  }
+
+  // 3. Fallback: plain repo (or unresolvable) -> current behavior.
+  return null;
+}

--- a/packages/core/src/infrastructure/di/modules/register-services.ts
+++ b/packages/core/src/infrastructure/di/modules/register-services.ts
@@ -44,6 +44,7 @@ import type { IToolInstallerService } from '../../../application/ports/output/se
 import { ToolInstallerServiceImpl } from '../../services/tool-installer/tool-installer.service.js';
 import type { IGitPrService } from '../../../application/ports/output/services/git-pr-service.interface.js';
 import { GitPrService } from '../../services/git/git-pr.service.js';
+import { GitRemoteListService } from '../../services/git/git-remote-list.service.js';
 import type { IGitForkService } from '../../../application/ports/output/services/git-fork-service.interface.js';
 import { GitForkService } from '../../services/git/git-fork.service.js';
 import type { ISkillInjectorService } from '../../../application/ports/output/services/skill-injector.interface.js';
@@ -267,6 +268,7 @@ export function registerServices(container: DependencyContainer): void {
   );
   container.registerSingleton<IGitPrService>('IGitPrService', GitPrService);
   container.registerSingleton<IGitForkService>('IGitForkService', GitForkService);
+  container.registerSingleton<GitRemoteListService>('GitRemoteListService', GitRemoteListService);
   container.registerSingleton<IGitHubRepositoryService>(
     'IGitHubRepositoryService',
     GitHubRepositoryService

--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -27,6 +27,7 @@ import type { IAgentExecutorProvider } from '@/application/ports/output/agents/a
 import type { IAgentExecutorFactory } from '@/application/ports/output/agents/agent-executor-factory.interface.js';
 import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
 import type { IGitPrService } from '@/application/ports/output/services/git-pr-service.interface.js';
+import { type GitRemoteListService } from '@/infrastructure/services/git/git-remote-list.service.js';
 import type { IGitForkService } from '@/application/ports/output/services/git-fork-service.interface.js';
 import {
   AgentRunStatus,
@@ -302,6 +303,7 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
 
   // Resolve merge node dependencies
   const gitPrService = container.resolve<IGitPrService>('IGitPrService');
+  const gitRemoteListService = container.resolve<GitRemoteListService>('GitRemoteListService');
   const featureRepository = container.resolve<IFeatureRepository>('IFeatureRepository');
   const cleanupFeatureWorktreeUseCase = container.resolve(CleanupFeatureWorktreeUseCase);
 
@@ -324,6 +326,8 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
         gitPrService.getPrDiffSummary(cwd, baseBranch),
       hasRemote: (cwd: string) => gitPrService.hasRemote(cwd),
       getDefaultBranch: (cwd: string) => gitPrService.getDefaultBranch(cwd),
+      listRemotes: (cwd: string) => gitRemoteListService.listRemotes(cwd),
+      getForkParentInfo: (cwd: string) => gitRemoteListService.getForkParentInfo(cwd),
       verifyMerge: (
         cwd: string,
         featureBranch: string,

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
@@ -40,6 +40,12 @@ import {
 import { updateNodeLifecycle, setFeatureLifecycle } from '../../lifecycle-context.js';
 import { buildCommitPushPrPrompt, buildLocalSquashMergePrompt } from '../prompts/merge-prompts.js';
 import {
+  resolvePrTarget,
+  type PrTarget,
+  type RemoteInfo,
+  type ForkParentInfo,
+} from '@/application/services/pr-target-resolution.js';
+import {
   GitPrError,
   GitPrErrorCode,
 } from '@/application/ports/output/services/git-pr-service.interface.js';
@@ -56,6 +62,18 @@ export interface MergeNodeDeps {
   getDiffSummary: (cwd: string, baseBranch: string) => Promise<DiffSummary>;
   hasRemote: (cwd: string) => Promise<boolean>;
   getDefaultBranch: (cwd: string) => Promise<string>;
+  /**
+   * List configured git remotes (name + URL). Used for upstream PR-target
+   * resolution; optional — when absent, PRs are created on origin (current
+   * behavior).
+   */
+  listRemotes?: (cwd: string) => Promise<RemoteInfo[]>;
+  /**
+   * Look up the GitHub fork-parent (parent repo + its default branch) via the
+   * gh CLI. Returns null on any failure or when not a fork. Optional — same
+   * fallback semantics as listRemotes.
+   */
+  getForkParentInfo?: (cwd: string) => Promise<ForkParentInfo | null>;
   featureRepository: Pick<IFeatureRepository, 'findById' | 'update'>;
   /**
    * Perform a local squash merge (deterministic git commands, no agent needed).
@@ -179,18 +197,34 @@ export function createMergeNode(deps: MergeNodeDeps) {
 
         const effectiveState = remoteAvailable ? state : { ...state, push: false, openPr: false };
 
+        let prTarget: PrTarget | null = null;
+        if (effectiveState.openPr && deps.listRemotes) {
+          try {
+            const remotes = await deps.listRemotes(cwd);
+            const forkParent = deps.getForkParentInfo ? await deps.getForkParentInfo(cwd) : null;
+            prTarget = resolvePrTarget({
+              remotes,
+              forkParent,
+              branch,
+              fallbackBaseBranch: baseBranch,
+            });
+            if (prTarget) {
+              log.info(`Upstream detected — PR will target ${prTarget.targetRepo}`);
+            }
+          } catch {
+            prTarget = null;
+          }
+        }
+
         log.info('Agent call 1: commit + push + PR');
         const mergePromptState = await applyMemorySelection(
           effectiveState,
           'merge',
           deps.selectMemory
         );
-        const commitPushPrPrompt = buildCommitPushPrPrompt(
-          mergePromptState,
-          branch,
-          baseBranch,
-          repoUrl
-        );
+        const commitPushPrPrompt = prTarget
+          ? buildCommitPushPrPrompt(mergePromptState, branch, baseBranch, repoUrl, prTarget)
+          : buildCommitPushPrPrompt(mergePromptState, branch, baseBranch, repoUrl);
         await updatePhasePrompt(mergeTimingId, commitPushPrPrompt);
         const commitResult = await retryExecute(executor, commitPushPrPrompt, options, {
           logger: log,
@@ -215,7 +249,9 @@ export function createMergeNode(deps: MergeNodeDeps) {
             // the real PR for this branch via the GitHub API.
             try {
               const prStatuses = await deps.gitPrService.listPrStatuses(cwd);
-              const matchingPr = prStatuses.find((pr) => pr.headRefName === branch);
+              const matchingPr = prStatuses.find(
+                (pr) => pr.headRefName === branch || pr.headRefName === prTarget?.headRef
+              );
               if (matchingPr) {
                 prUrl = matchingPr.url;
                 prNumber = matchingPr.number;

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -15,6 +15,7 @@ import { readSpecFile, buildResumeContext } from '../node-helpers.js';
 import { buildProjectMemorySection, renderProjectMemoryBlock } from './project-memory-section.js';
 import type { FeatureAgentState } from '../../state.js';
 import { PR_BRANDING, COMMIT_CO_AUTHOR } from './pr-branding.js';
+import type { PrTarget } from '@/application/services/pr-target-resolution.js';
 
 /**
  * Extract merge-phase rejection feedback from spec.yaml.
@@ -139,7 +140,8 @@ export function buildCommitPushPrPrompt(
   state: FeatureAgentState,
   branch: string,
   baseBranch: string,
-  repoUrl?: string
+  repoUrl?: string,
+  prTarget?: PrTarget | null
 ): string {
   const specContent = readSpecFile(state.specDir, 'spec.yaml');
   const cwd = state.worktreePath || state.repositoryPath;
@@ -178,8 +180,11 @@ export function buildCommitPushPrPrompt(
 
   // Step 3: PR creation (conditional)
   if (state.openPr) {
+    const prCreateCmd = prTarget
+      ? `gh pr create --repo ${prTarget.targetRepo} --base ${prTarget.baseBranch} --head ${prTarget.headRef} --title "<title>" --body "<body>"`
+      : `gh pr create --base ${baseBranch} --head ${branch} --title "<title>" --body "<body>"`;
     steps.push(`${shouldPush ? '6' : '4'}. Create a pull request:
-   - Run \`gh pr create --base ${baseBranch} --head ${branch} --title "<title>" --body "<body>"\`
+   - Run \`${prCreateCmd}\`
    - Write a descriptive PR title using conventional commit format
    - Write a rich PR body that summarizes the changes using the spec context below
    - The PR body MUST end with this exact branding line (on its own line): \`${PR_BRANDING}\`
@@ -217,7 +222,8 @@ ${rejectionSection ? '- You MUST modify source code files to address the rejecti
 ${!state.commitSpecs ? '- Do NOT commit the `specs/` directory — it must stay untracked. If you accidentally staged it, run `git reset -- specs/` before committing' : ''}
 - Do NOT amend existing commits
 - Do NOT run \`git pull\`, \`git rebase\`, or \`git merge\` — this is a fresh branch, push it directly
-- If there are no changes to commit, skip the commit step and report that no changes were found`;
+- If there are no changes to commit, skip the commit step and report that no changes were found
+${prTarget ? `- The PR MUST be created on \`${prTarget.targetRepo}\` (upstream), NOT on the origin/fork repository — use the exact \`gh pr create\` command provided above` : ''}`;
 }
 
 /**

--- a/packages/core/src/infrastructure/services/git/git-remote-list.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-remote-list.service.ts
@@ -1,0 +1,52 @@
+import { injectable, inject } from 'tsyringe';
+import type {
+  RemoteInfo,
+  ForkParentInfo,
+} from '../../../application/services/pr-target-resolution.js';
+import type { ExecFunction } from './worktree.service.js';
+
+/**
+ * Read-only git/gh lookups backing upstream PR-target resolution in the
+ * feature-agent merge node. Errors are swallowed (returning empty/null) so a
+ * broken gh or missing upstream can never break the standard origin flow.
+ */
+@injectable()
+export class GitRemoteListService {
+  constructor(@inject('ExecFunction') private readonly execFile: ExecFunction) {}
+
+  async listRemotes(cwd: string): Promise<RemoteInfo[]> {
+    const { stdout } = await this.execFile('git', ['remote', '-v'], { cwd });
+    const byName = new Map<string, string>();
+    for (const line of stdout.split('\n')) {
+      const match = /^(\S+)\t(\S+)\s+\(fetch\)$/.exec(line.trim());
+      if (match) byName.set(match[1], match[2]);
+    }
+    return [...byName].map(([name, url]) => ({ name, url }));
+  }
+
+  async getForkParentInfo(cwd: string): Promise<ForkParentInfo | null> {
+    try {
+      const { stdout } = await this.execFile('gh', ['repo', 'view', '--json', 'parent'], { cwd });
+      const parent = (
+        JSON.parse(stdout) as { parent?: { name?: string; owner?: { login?: string } } | null }
+      ).parent;
+      const owner = parent?.owner?.login;
+      const repo = parent?.name;
+      if (!owner || !repo) return null;
+
+      const { stdout: branchStdout } = await this.execFile(
+        'gh',
+        ['repo', 'view', `${owner}/${repo}`, '--json', 'defaultBranchRef'],
+        { cwd }
+      );
+      const defaultBranch = (
+        JSON.parse(branchStdout) as { defaultBranchRef?: { name?: string } | null }
+      ).defaultBranchRef?.name;
+      if (!defaultBranch) return null;
+
+      return { owner, repo, defaultBranch };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/tests/unit/application/services/pr-target-resolution.test.ts
+++ b/tests/unit/application/services/pr-target-resolution.test.ts
@@ -1,0 +1,122 @@
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePrTarget,
+  type PrTargetInputs,
+} from '@/application/services/pr-target-resolution.js';
+
+const sshUrl = 'git@github.com:kevinnguyenhoang91/shep.git';
+const upstreamSshUrl = 'git@github.com:shep-ai/shep.git';
+const httpsUrl = 'https://github.com/kevinnguyenhoang91/shep.git';
+
+function inputs(overrides: Partial<PrTargetInputs> = {}): PrTargetInputs {
+  return {
+    remotes: [
+      { name: 'origin', url: sshUrl },
+      { name: 'upstream', url: upstreamSshUrl },
+    ],
+    forkParent: null,
+    branch: 'fix/pr_upstream',
+    fallbackBaseBranch: 'main',
+    ...overrides,
+  };
+}
+
+describe('resolvePrTarget', () => {
+  it('resolves upstream target when an upstream remote exists (SSH url)', () => {
+    expect(resolvePrTarget(inputs())).toEqual({
+      targetRepo: 'shep-ai/shep',
+      baseBranch: 'main',
+      headRef: 'kevinnguyenhoang91:fix/pr_upstream',
+    });
+  });
+
+  it('resolves upstream target from HTTPS urls', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          remotes: [
+            { name: 'origin', url: httpsUrl },
+            { name: 'upstream', url: 'https://github.com/shep-ai/shep.git' },
+          ],
+        })
+      )
+    ).toEqual({
+      targetRepo: 'shep-ai/shep',
+      baseBranch: 'main',
+      headRef: 'kevinnguyenhoang91:fix/pr_upstream',
+    });
+  });
+
+  it('uses forkParent default branch as base when parent matches upstream remote', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          forkParent: {
+            owner: 'shep-ai',
+            repo: 'shep',
+            defaultBranch: 'develop',
+          },
+        })
+      )
+    ).toMatchObject({ targetRepo: 'shep-ai/shep', baseBranch: 'develop' });
+  });
+
+  it('falls back to forkParent when no upstream remote exists', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          remotes: [{ name: 'origin', url: sshUrl }],
+          forkParent: { owner: 'shep-ai', repo: 'shep', defaultBranch: 'main' },
+        })
+      )
+    ).toEqual({
+      targetRepo: 'shep-ai/shep',
+      baseBranch: 'main',
+      headRef: 'kevinnguyenhoang91:fix/pr_upstream',
+    });
+  });
+
+  it('returns null for a plain repo without upstream or fork parent', () => {
+    expect(resolvePrTarget(inputs({ remotes: [{ name: 'origin', url: sshUrl }] }))).toBeNull();
+  });
+
+  it('returns null when upstream remote is unparseable', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          remotes: [
+            { name: 'origin', url: sshUrl },
+            { name: 'upstream', url: 'not-a-url' },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('returns null when origin cannot be parsed for head qualification', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          remotes: [
+            { name: 'origin', url: 'file:///local/path' },
+            { name: 'upstream', url: upstreamSshUrl },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('returns null when upstream remote url is empty', () => {
+    expect(
+      resolvePrTarget(
+        inputs({
+          remotes: [
+            { name: 'origin', url: sshUrl },
+            { name: 'upstream', url: '' },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.pr-target.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.pr-target.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock(
+  '@/infrastructure/services/agents/feature-agent/nodes/node-helpers.js',
+  async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return {
+      ...actual,
+      readSpecFile: vi.fn().mockReturnValue('name: Test Feature\nsummary: A test feature\n'),
+    };
+  }
+);
+
+import { buildCommitPushPrPrompt } from '@/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.js';
+import type { PrTarget } from '@/application/services/pr-target-resolution.js';
+import type { FeatureAgentState } from '@/infrastructure/services/agents/feature-agent/state.js';
+
+function baseState(overrides: Partial<FeatureAgentState> = {}): FeatureAgentState {
+  return {
+    featureId: 'feat-001',
+    repositoryPath: '/tmp/repo',
+    worktreePath: '/tmp/worktree',
+    specDir: '/tmp/specs',
+    currentNode: 'merge',
+    error: null,
+    messages: [],
+    approvalGates: undefined,
+    validationRetries: 0,
+    lastValidationTarget: '',
+    lastValidationErrors: [],
+    prUrl: null,
+    prNumber: null,
+    commitHash: null,
+    ciStatus: null,
+    push: false,
+    openPr: true,
+    evidence: [],
+    ...overrides,
+  } as FeatureAgentState;
+}
+
+const upstreamTarget: PrTarget = {
+  targetRepo: 'shep-ai/shep',
+  baseBranch: 'main',
+  headRef: 'kevinnguyenhoang91:fix/pr_upstream',
+};
+
+describe('buildCommitPushPrPrompt — PR target resolution', () => {
+  it('instructs PR creation on upstream when a target is resolved', () => {
+    const prompt = buildCommitPushPrPrompt(
+      baseState(),
+      'fix/pr_upstream',
+      'main',
+      undefined,
+      upstreamTarget
+    );
+    expect(prompt).toContain(
+      'gh pr create --repo shep-ai/shep --base main --head kevinnguyenhoang91:fix/pr_upstream'
+    );
+    expect(prompt).toContain('MUST be created on `shep-ai/shep` (upstream)');
+    expect(prompt).not.toContain('gh pr create --base main --head fix/pr_upstream ');
+  });
+
+  it('keeps the origin instruction byte-identical when no target is resolved', () => {
+    const prompt = buildCommitPushPrPrompt(baseState(), 'feat/test', 'main', undefined, null);
+    expect(prompt).toContain('gh pr create --base main --head feat/test');
+    expect(prompt).not.toContain('--repo');
+    expect(prompt).not.toContain('upstream');
+  });
+
+  it('preserves current behavior when prTarget argument is omitted entirely', () => {
+    const withArg = buildCommitPushPrPrompt(baseState(), 'feat/test', 'main', undefined, null);
+    const withoutArg = buildCommitPushPrPrompt(baseState(), 'feat/test', 'main');
+    expect(withoutArg).toContain('gh pr create --base main --head feat/test');
+    expect(withoutArg).not.toContain('--repo');
+    expect(withoutArg).toBe(withArg);
+  });
+});


### PR DESCRIPTION
## What

When the working repository is a fork, Shep now creates the feature PR on the **upstream** repository instead of on the fork: the merge step resolves the PR target before building the agent prompt and instructs `gh pr create --repo <upstream> --base <upstream-default-branch> --head <fork-owner>:<branch>`. The branch push stays on `origin`. Non-fork repos produce byte-identical prompts (locked by test).

## Why

Implements the `pr-upstream-instead-fork` spec: "When create PR, create on the upstream instead of on the fork repo". Previously the merge prompt instructed a bare `gh pr create --base <base> --head <branch>`, which defaults to `origin` — so a contributor working in a fork (e.g. `kevinnguyenhoang91/shep` → upstream `shep-ai/shep`) got a PR on the fork where maintainers never see it and upstream CI never runs. The symptom was silent: no error, just a PR in the wrong place.

Detection is conservative (most-conservative-wins):

1. **Primary:** explicit `upstream` git remote with a parseable GitHub URL
2. **Secondary:** GitHub fork-parent via `gh repo view --json parent` when no `upstream` remote exists
3. **Fallback:** any absence/ambiguity/failure → `null` → current origin behavior

## Screenshots / Recording

N/A — non-UI change.

## Testing

TDD-first (RED → GREEN):

- `tests/unit/application/services/pr-target-resolution.test.ts` — 8 tests: upstream remote (SSH + HTTPS), fork-parent fallback, fork-parent base-branch matching, plain repo → null, unparseable upstream → null, unparseable origin → null, empty URL → null
- `tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.pr-target.test.ts` — 3 tests: upstream instruction + anti-origin constraint line, byte-identical fallback (`toBe` equality), omitted-arg parity

Commands run and green:

- `pnpm vitest run tests/unit` — 912 files / 10,544 tests passed
- `pnpm vitest run tests/integration` — 132 files / 1,566 tests passed
- `pnpm typecheck` (tsc --noEmit) — clean
- `pnpm lint` (eslint --max-warnings 0 on all changed files) — clean

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` and `pnpm test:int` pass
- [ ] `pnpm build` succeeds (CI will verify; typecheck + hooks already green)
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/` (the new pure resolver has zero imports)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `fix` used for user-visible change
- [x] (New use case) Tests landed RED-first per the [TDD guide](./docs/development/tdd-guide.md)
