### PR TITLE
fix(agents): exclude injected skills from feature commits

### DIFF
--- a/packages/core/src/application/ports/output/services/skill-injector.interface.ts
+++ b/packages/core/src/application/ports/output/services/skill-injector.interface.ts
@@ -3,7 +3,11 @@
  *
  * Output port for injecting curated agent skills into worktrees
  * during feature creation. Handles local skill copying, remote skill
- * installation via npx, idempotency checks, and .gitignore management.
+ * installation via npx, and idempotency checks.
+ *
+ * Injected skills are worktree-local tooling: the injector never modifies
+ * `.gitignore`, and commits exclude newly-added files under `.claude/skills/`
+ * at staging time (see IGitCommitService).
  */
 
 import type { SkillInjectionConfig } from '../../../../domain/generated/output.js';
@@ -25,7 +29,8 @@ export interface ISkillInjectorService {
    * - Local skills are deep-copied from the source path
    * - Remote skills are installed via `npx skills add`
    * - Skills already present (SKILL.md exists) are skipped
-   * - Newly injected skills are added to .gitignore (unless already tracked in git)
+   * - Injected skills are never added to `.gitignore`; they are excluded
+   *   from commits at staging time instead
    *
    * Individual skill failures are captured in the result (not thrown).
    *

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -117,8 +117,8 @@ export function buildCommitPushPrPrompt(
 
   // Step 1: Commit (always)
   const stageCmd = state.commitSpecs
-    ? '`git add -A`'
-    : '`git add -A` then `git reset -- specs/` (do NOT commit the specs/ directory)';
+    ? '`git add -A` then `git reset -- .claude/skills/` (do NOT commit injected skills)'
+    : '`git add -A` then `git reset -- specs/ .claude/skills/` (do NOT commit the specs/ directory or injected skills)';
   steps.push(`1. Review the current changes using \`git diff\` and \`git status\`
 2. Stage changes with ${stageCmd}
 3. Write a conventional commit message based on the actual diff content
@@ -181,6 +181,7 @@ ${evidenceSection}
 - Every commit MUST include the co-author trailer: \`${COMMIT_CO_AUTHOR}\` — do NOT include any other Co-Authored-By trailer
 ${rejectionSection ? '- You MUST modify source code files to address the rejection feedback above BEFORE committing' : '- Do NOT modify any source code files — only perform git operations'}
 ${!state.commitSpecs ? '- Do NOT commit the `specs/` directory — it must stay untracked. If you accidentally staged it, run `git reset -- specs/` before committing' : ''}
+- Do NOT commit the \`.claude/skills/\` directory — injected skills are worktree-local tooling and must never appear in commits or PRs. If you accidentally staged skill files, run \`git reset -- .claude/skills/\` before committing
 - Do NOT amend existing commits
 - Do NOT run \`git pull\`, \`git rebase\`, or \`git merge\` — this is a fresh branch, push it directly
 - If there are no changes to commit, skip the commit step and report that no changes were found
@@ -289,7 +290,7 @@ ${failureLogs}
 
 1. Analyze the CI failure logs above to diagnose the root cause
 2. Apply a targeted fix to resolve the failure — change only what is necessary
-3. Stage all changes: \`git add -A\`
+3. Stage all changes: \`git add -A\`, then unstage injected skills: \`git reset -- .claude/skills/\` (injected skills must never be committed)
 4. Commit with this exact conventional commit message format and the Shep Bot co-author trailer:
    \`git commit -m "fix(ci): attempt ${attemptNumber}/${maxAttempts} — <short description of what you fixed>" -m "" -m "${COMMIT_CO_AUTHOR}"\`
 5. Push the fix to the branch: \`git push origin ${branch}\`

--- a/packages/core/src/infrastructure/services/git/git-commit.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-commit.service.ts
@@ -21,6 +21,13 @@ import {
 } from '../../../application/ports/output/services/git-commit.service.interface.js';
 import type { ExecFunction } from './worktree.service.js';
 
+/**
+ * Pathspec under which Shep injects agent skills into feature worktrees.
+ * Injected skills are worktree-local tooling and must never be committed,
+ * so staging always unstages newly-added files under this path.
+ */
+const INJECTED_SKILLS_PATHSPEC = '.claude/skills/';
+
 @injectable()
 export class GitCommitService implements IGitCommitService {
   constructor(@inject('ExecFunction') private readonly execFile: ExecFunction) {}
@@ -58,6 +65,8 @@ export class GitCommitService implements IGitCommitService {
       throw new GitCommitError(`git add failed: ${messageText}`);
     }
 
+    await this.unstageInjectedSkills(cwd);
+
     // If the working tree is clean, skip the commit entirely.
     const hasStaged = await this.hasStagedChanges(cwd);
     if (!hasStaged) {
@@ -72,6 +81,43 @@ export class GitCommitService implements IGitCommitService {
     }
 
     return { committed: true };
+  }
+
+  /**
+   * Unstage newly-added files under `.claude/skills/` so injected skills
+   * never enter a commit. Only files that are *newly added* relative to HEAD
+   * are unstaged — edits to skills already tracked in the repo stay staged
+   * and committable.
+   *
+   * Best-effort by design: if git cannot enumerate the added files, fall back
+   * to unstaging the whole directory (mirroring the specs/ convention); if
+   * that fails too, continue so the exclusion never breaks an ordinary commit.
+   */
+  private async unstageInjectedSkills(cwd: string): Promise<void> {
+    try {
+      const { stdout } = await this.execFile(
+        'git',
+        [
+          'diff',
+          '--cached',
+          '--name-only',
+          '--diff-filter=A',
+          '-z',
+          '--',
+          INJECTED_SKILLS_PATHSPEC,
+        ],
+        { cwd }
+      );
+      const addedFiles = stdout.split('\0').filter((path) => path.length > 0);
+      if (addedFiles.length === 0) return;
+      await this.execFile('git', ['reset', '-q', '--', ...addedFiles], { cwd });
+    } catch {
+      try {
+        await this.execFile('git', ['reset', '-q', '--', INJECTED_SKILLS_PATHSPEC], { cwd });
+      } catch {
+        // Exclusion is best-effort — never block an ordinary commit.
+      }
+    }
   }
 
   private async hasStagedChanges(cwd: string): Promise<boolean> {

--- a/packages/core/src/infrastructure/services/skill-injector.service.ts
+++ b/packages/core/src/infrastructure/services/skill-injector.service.ts
@@ -3,14 +3,18 @@
  *
  * Injects curated agent skills into worktrees during feature creation.
  * Handles local skill copying via fs.cp, remote skill installation via npx,
- * SKILL.md idempotency checks, and .gitignore management.
+ * and SKILL.md idempotency checks.
+ *
+ * Injected skills are worktree-local tooling: the injector never writes to
+ * the (tracked) .gitignore, and commits exclude newly-added files under
+ * `.claude/skills/` at staging time (see GitCommitService).
  *
  * Uses constructor-injected ExecFunction for process execution (npx, git)
  * and direct fs/promises imports for filesystem operations, following
  * the established codebase conventions.
  */
 
-import { access, cp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, cp, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { injectable, inject } from 'tsyringe';
 
@@ -80,10 +84,6 @@ export class SkillInjectorService implements ISkillInjectorService {
         await this.injectRemoteSkill(worktreePath, skill, result);
       }
     }
-
-    // Update .gitignore for injected and skipped untracked skills
-    const allSkillNames = [...result.injected, ...result.skipped];
-    await this.updateGitignore(worktreePath, allSkillNames);
 
     return result;
   }
@@ -166,61 +166,5 @@ export class SkillInjectorService implements ISkillInjectorService {
     } finally {
       clearTimeout(timer);
     }
-  }
-
-  private async isTrackedInGit(worktreePath: string, skillName: string): Promise<boolean> {
-    try {
-      await this.execFile('git', ['ls-files', '--error-unmatch', `${SKILLS_DIR}/${skillName}/`], {
-        cwd: worktreePath,
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async updateGitignore(worktreePath: string, skillNames: string[]): Promise<void> {
-    if (!skillNames.length) return;
-
-    // Determine which skills need .gitignore entries (untracked only)
-    const untrackedSkills: string[] = [];
-    for (const name of skillNames) {
-      if (!(await this.isTrackedInGit(worktreePath, name))) {
-        untrackedSkills.push(name);
-      }
-    }
-
-    if (!untrackedSkills.length) return;
-
-    const gitignorePath = join(worktreePath, '.gitignore');
-
-    // Read existing .gitignore (or start with empty string)
-    let existingContent = '';
-    try {
-      const content = await readFile(gitignorePath, 'utf-8');
-      existingContent = typeof content === 'string' ? content : '';
-    } catch {
-      // File doesn't exist — will create it
-    }
-
-    // Determine which entries are new
-    const existingLines = new Set(existingContent.split('\n').map((line) => line.trim()));
-    const newEntries: string[] = [];
-
-    for (const name of untrackedSkills) {
-      const pattern = `${SKILLS_DIR}/${name}/`;
-      if (!existingLines.has(pattern)) {
-        newEntries.push(pattern);
-      }
-    }
-
-    if (!newEntries.length) return;
-
-    // Append new entries, ensuring trailing newline
-    const needsNewline = existingContent.length > 0 && !existingContent.endsWith('\n');
-    const separator = needsNewline ? '\n' : '';
-    const updatedContent = `${existingContent + separator + newEntries.join('\n')}\n`;
-
-    await writeFile(gitignorePath, updatedContent);
   }
 }

--- a/tests/integration/infrastructure/services/git/git-commit.service.skills-exclusion.test.ts
+++ b/tests/integration/infrastructure/services/git/git-commit.service.skills-exclusion.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration: GitCommitService must never commit injected skills
+ *
+ * Uses a real git repository to prove that `stageAndCommit` unstages
+ * newly-added files under `.claude/skills/` (injected, worktree-local skills)
+ * while still committing ordinary files and edits to repo-tracked skills.
+ *
+ * Regression test for the injected-skill leak into Merge Review commits.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { GitCommitService } from '../../../../../packages/core/src/infrastructure/services/git/git-commit.service.js';
+import type { ExecFunction } from '../../../../../packages/core/src/infrastructure/services/git/worktree.service.js';
+
+const execFileRaw = promisify(execFileCb);
+
+function makeRealExec(): ExecFunction {
+  return (file, args, options) =>
+    execFileRaw(file, args, { encoding: 'utf-8', ...(options ?? {}) });
+}
+
+function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return makeRealExec()('git', args, { cwd });
+}
+
+function destroyDirs(dirs: string[]): void {
+  for (const dir of dirs) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
+/** Repo state: main with README.md + a repo-tracked skill committed. */
+async function createRepo(): Promise<string> {
+  const repoDir = mkdtempSync(join(tmpdir(), 'shep-commit-skills-'));
+  await git(repoDir, ['init', '-b', 'main']);
+  await git(repoDir, ['config', 'user.email', 'test@shep.test']);
+  await git(repoDir, ['config', 'user.name', 'Shep Test']);
+  await git(repoDir, ['config', 'core.autocrlf', 'false']);
+
+  writeFileSync(join(repoDir, 'README.md'), '# Test Repo\n');
+  const trackedSkill = join(repoDir, '.claude', 'skills', 'repo-skill');
+  mkdirSync(trackedSkill, { recursive: true });
+  writeFileSync(join(trackedSkill, 'SKILL.md'), '# Repo tracked skill\n');
+
+  await git(repoDir, ['add', '-A']);
+  await git(repoDir, ['commit', '-m', 'Initial commit']);
+  return repoDir;
+}
+
+async function committedFiles(repoDir: string): Promise<string[]> {
+  const { stdout } = await git(repoDir, ['show', '--name-only', '--format=', 'HEAD']);
+  return stdout.split('\n').filter((line) => line.trim().length > 0);
+}
+
+async function statusEntries(repoDir: string): Promise<string[]> {
+  const { stdout } = await git(repoDir, ['status', '--porcelain']);
+  return stdout.split('\n').filter((line) => line.trim().length > 0);
+}
+
+describe('GitCommitService — injected skills exclusion (real git)', () => {
+  let repoDir: string;
+
+  beforeEach(async () => {
+    repoDir = await createRepo();
+  });
+
+  afterEach(() => {
+    destroyDirs([repoDir]);
+  });
+
+  it('commits ordinary files and tracked-skill edits, but not injected skills', async () => {
+    writeFileSync(join(repoDir, 'src-feature.ts'), '// Feature implementation\n');
+    const trackedSkillFile = join(repoDir, '.claude', 'skills', 'repo-skill', 'SKILL.md');
+    writeFileSync(trackedSkillFile, '# Repo tracked skill — edited by feature\n');
+    const injectedSkill = join(repoDir, '.claude', 'skills', 'injected-skill');
+    mkdirSync(injectedSkill, { recursive: true });
+    writeFileSync(join(injectedSkill, 'SKILL.md'), '# Injected worktree-local skill\n');
+
+    const service = new GitCommitService(makeRealExec());
+    const result = await service.commitChanges({
+      cwd: repoDir,
+      message: 'feat: add feature',
+    });
+
+    expect(result.committed).toBe(true);
+    const files = await committedFiles(repoDir);
+    expect(files).toContain('src-feature.ts');
+    expect(files).toContain('.claude/skills/repo-skill/SKILL.md');
+    expect(files).not.toContain('.claude/skills/injected-skill/SKILL.md');
+
+    // The injected skill must remain worktree-local: present on disk, still untracked.
+    const status = await statusEntries(repoDir);
+    expect(status.some((line) => line.includes('.claude/skills/injected-skill/'))).toBe(true);
+  });
+
+  it('skips the commit when the only staged content is injected skills', async () => {
+    const injectedSkill = join(repoDir, '.claude', 'skills', 'injected-skill');
+    mkdirSync(injectedSkill, { recursive: true });
+    writeFileSync(join(injectedSkill, 'SKILL.md'), '# Injected worktree-local skill\n');
+
+    const service = new GitCommitService(makeRealExec());
+    const result = await service.commitChanges({
+      cwd: repoDir,
+      message: 'feat: should not commit',
+    });
+
+    expect(result.committed).toBe(false);
+
+    // Nothing new was committed and the skill is still untracked in the worktree.
+    const files = await committedFiles(repoDir);
+    expect(files).not.toContain('.claude/skills/injected-skill/SKILL.md');
+    const status = await statusEntries(repoDir);
+    expect(status.some((line) => line.includes('.claude/skills/injected-skill/'))).toBe(true);
+  });
+});

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ci-watch-fix.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ci-watch-fix.test.ts
@@ -53,6 +53,12 @@ describe('buildCiWatchFixPrompt', () => {
     expect(prompt.toLowerCase()).toMatch(/diagnos|analyz|investigat|fix/);
   });
 
+  it('excludes injected skills from staging', () => {
+    const prompt = buildCiWatchFixPrompt('some failure log', 1, 3, 'feat/my-branch');
+
+    expect(prompt).toContain('git reset -- .claude/skills/');
+  });
+
   it('is deterministic (same input = same output)', () => {
     const prompt1 = buildCiWatchFixPrompt('error log', 1, 3, 'feat/test');
     const prompt2 = buildCiWatchFixPrompt('error log', 1, 3, 'feat/test');

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
@@ -158,6 +158,22 @@ describe('buildCommitPushPrPrompt', () => {
     expect(prompt).toContain('git merge');
   });
 
+  it('should instruct agent to unstage injected skills when staging (commitSpecs=true)', () => {
+    const prompt = buildCommitPushPrPrompt(baseState({ commitSpecs: true }), 'feat/test', 'main');
+    expect(prompt).toContain('`git add -A` then `git reset -- .claude/skills/`');
+  });
+
+  it('should exclude both specs and injected skills when commitSpecs is false', () => {
+    const prompt = buildCommitPushPrPrompt(baseState({ commitSpecs: false }), 'feat/test', 'main');
+    expect(prompt).toContain('`git add -A` then `git reset -- specs/ .claude/skills/`');
+  });
+
+  it('should forbid committing the .claude/skills/ directory in constraints', () => {
+    const prompt = buildCommitPushPrPrompt(baseState(), 'feat/test', 'main');
+    expect(prompt).toContain('Do NOT commit the `.claude/skills/` directory');
+    expect(prompt).toContain('git reset -- .claude/skills/` before committing');
+  });
+
   it('should be deterministic (same input = same output)', () => {
     const state = baseState({ push: true, openPr: true });
     const prompt1 = buildCommitPushPrPrompt(state, 'feat/test', 'main');

--- a/tests/unit/infrastructure/services/git/git-commit.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-commit.service.test.ts
@@ -1,0 +1,197 @@
+/**
+ * GitCommitService Unit Tests — injected-skills staging exclusion
+ *
+ * Injected skills (.claude/skills/) are worktree-local tooling and must never
+ * be committed. stageAndCommit must unstage newly-added files under that path
+ * after `git add -A` while keeping edits to repo-tracked skills staged.
+ *
+ * TDD Phase: RED
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+
+import { GitCommitService } from '@/infrastructure/services/git/git-commit.service.js';
+import {
+  GitCommitError,
+  GitPushError,
+} from '@/application/ports/output/services/git-commit.service.interface.js';
+
+type ExecFileFn = (
+  cmd: string,
+  args: string[],
+  options?: object
+) => Promise<{ stdout: string; stderr: string }>;
+
+const CWD = '/worktree/project';
+const ADDED_SKILLS_QUERY = [
+  'diff',
+  '--cached',
+  '--name-only',
+  '--diff-filter=A',
+  '-z',
+  '--',
+  '.claude/skills/',
+];
+
+interface ExecOverrides {
+  add?: 'throw' | 'ok';
+  addedSkillsStdout?: string | 'throw';
+  hasStagedStdout?: string;
+  reset?: 'throw' | 'ok';
+  remote?: string | 'throw';
+}
+
+function makeExec(overrides: ExecOverrides = {}): ReturnType<typeof vi.fn<ExecFileFn>> {
+  return vi.fn<ExecFileFn>(async (_cmd: string, args: string[]) => {
+    const head = args[0];
+    if (head === 'add') {
+      if (overrides.add === 'throw') throw new Error('fatal: not a git repository');
+      return { stdout: '', stderr: '' };
+    }
+    if (head === 'diff' && args.includes('--diff-filter=A')) {
+      if (overrides.addedSkillsStdout === 'throw') throw new Error('unexpected diff failure');
+      return { stdout: overrides.addedSkillsStdout ?? '', stderr: '' };
+    }
+    if (head === 'diff') {
+      return { stdout: overrides.hasStagedStdout ?? 'src/index.ts\n', stderr: '' };
+    }
+    if (head === 'reset') {
+      if (overrides.reset === 'throw') throw new Error('reset failed');
+      return { stdout: '', stderr: '' };
+    }
+    if (head === 'commit') return { stdout: '', stderr: '' };
+    if (head === 'remote') {
+      if (overrides.remote === 'throw') throw new Error('No origin configured');
+      return { stdout: overrides.remote ?? 'https://github.com/o/r.git', stderr: '' };
+    }
+    if (head === 'push') return { stdout: '', stderr: '' };
+    throw new Error(`unexpected git args: ${args.join(' ')}`);
+  });
+}
+
+describe('GitCommitService — injected skills staging exclusion', () => {
+  it('unstages newly-added .claude/skills/ files between staging and commit', async () => {
+    const exec = makeExec({
+      addedSkillsStdout: '.claude/skills/foo/SKILL.md\0.claude/skills/foo/\0',
+    });
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitChanges({ cwd: CWD, message: 'feat: test' });
+
+    expect(result.committed).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      'git',
+      ADDED_SKILLS_QUERY,
+      expect.objectContaining({ cwd: CWD })
+    );
+    expect(exec).toHaveBeenCalledWith(
+      'git',
+      ['reset', '-q', '--', '.claude/skills/foo/SKILL.md', '.claude/skills/foo/'],
+      expect.objectContaining({ cwd: CWD })
+    );
+
+    const calls = exec.mock.calls.map((c) => `${c[1][0]}:${c[1][1] ?? ''}`);
+    const addIdx = calls.findIndex((c) => c.startsWith('add:'));
+    const queryIdx = calls.findIndex((c) => c.startsWith('diff:'));
+    const resetIdx = calls.findIndex((c) => c.startsWith('reset:'));
+    const commitIdx = calls.findIndex((c) => c.startsWith('commit:'));
+    expect(addIdx).toBeLessThan(queryIdx);
+    expect(queryIdx).toBeLessThan(resetIdx);
+    expect(resetIdx).toBeLessThan(commitIdx);
+  });
+
+  it('commits edits to repo-tracked skills without resetting (only newly-added files are excluded)', async () => {
+    const exec = makeExec();
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitChanges({ cwd: CWD, message: 'feat: edit tracked skill' });
+
+    expect(result.committed).toBe(true);
+    expect(exec).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['reset']),
+      expect.anything()
+    );
+    expect(exec).toHaveBeenCalledWith(
+      'git',
+      ['commit', '-m', 'feat: edit tracked skill'],
+      expect.objectContaining({ cwd: CWD })
+    );
+  });
+
+  it('skips the commit entirely when only injected skills were staged', async () => {
+    const exec = makeExec({
+      addedSkillsStdout: '.claude/skills/foo/SKILL.md\0',
+      hasStagedStdout: '',
+    });
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitChanges({ cwd: CWD, message: 'feat: only skills' });
+
+    expect(result.committed).toBe(false);
+    expect(exec).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['commit']),
+      expect.anything()
+    );
+  });
+
+  it('falls back to unstaging the whole skills directory when enumeration fails', async () => {
+    const exec = makeExec({ addedSkillsStdout: 'throw' });
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitChanges({ cwd: CWD, message: 'feat: test' });
+
+    expect(result.committed).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      'git',
+      ['reset', '-q', '--', '.claude/skills/'],
+      expect.objectContaining({ cwd: CWD })
+    );
+  });
+
+  it('still commits when the fallback reset also fails', async () => {
+    const exec = makeExec({ addedSkillsStdout: 'throw', reset: 'throw' });
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitChanges({ cwd: CWD, message: 'feat: test' });
+
+    expect(result.committed).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      'git',
+      ['commit', '-m', 'feat: test'],
+      expect.objectContaining({ cwd: CWD })
+    );
+  });
+
+  it('throws GitCommitError when staging fails', async () => {
+    const exec = makeExec({ add: 'throw' });
+    const service = new GitCommitService(exec);
+
+    await expect(service.commitChanges({ cwd: CWD, message: 'feat: test' })).rejects.toThrow(
+      GitCommitError
+    );
+  });
+
+  it('commitAndPush pushes after committing', async () => {
+    const exec = makeExec({
+      addedSkillsStdout: '.claude/skills/foo/SKILL.md\0',
+    });
+    const service = new GitCommitService(exec);
+
+    const result = await service.commitAndPush({ cwd: CWD, message: 'feat: test' });
+
+    expect(result).toEqual({ committed: true, pushed: true });
+    expect(exec).toHaveBeenCalledWith('git', ['push', 'origin', 'HEAD'], expect.anything());
+  });
+
+  it('throws GitPushError when no origin remote exists', async () => {
+    const exec = makeExec({ remote: 'throw' });
+    const service = new GitCommitService(exec);
+
+    await expect(service.commitAndPush({ cwd: CWD, message: 'feat: test' })).rejects.toThrow(
+      GitPushError
+    );
+  });
+});

--- a/tests/unit/infrastructure/services/skill-injector.service.test.ts
+++ b/tests/unit/infrastructure/services/skill-injector.service.test.ts
@@ -358,10 +358,14 @@ describe('SkillInjectorService', () => {
     });
   });
 
-  // --- Task 7: .gitignore management ---
+  // --- Task 7: .gitignore non-interference ---
 
-  describe('.gitignore management', () => {
-    it('should append injected untracked skill to .gitignore', async () => {
+  // Injected skills are worktree-local tooling. The injector must NEVER write
+  // to the (tracked) .gitignore: any write there produces an uncommitted diff
+  // that later leaks into the Merge Review commit via `git add -A`.
+  // Skills are kept out of commits at staging time instead (GitCommitService).
+  describe('.gitignore non-interference', () => {
+    it('should NOT modify .gitignore when injecting an untracked skill', async () => {
       const config: SkillInjectionConfig = {
         enabled: true,
         skills: [
@@ -377,22 +381,18 @@ describe('SkillInjectorService', () => {
         const path = String(p);
         if (path.includes('SKILL.md')) throw new Error('ENOENT');
       });
-
-      // git ls-files: not tracked
+      // git ls-files: untracked — the exact case the old code wrote entries for
       mockExecFile.mockRejectedValue(new Error('not tracked'));
-
-      // .gitignore exists with some content
+      // .gitignore exists with unrelated content
       mockReadFile.mockResolvedValue('node_modules/\n');
 
-      await service.inject(worktreePath, config, repoRoot);
+      const result = await service.inject(worktreePath, config, repoRoot);
 
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('.gitignore'),
-        expect.stringContaining('.claude/skills/new-skill/')
-      );
+      expect(result.injected).toContain('new-skill');
+      expect(mockWriteFile).not.toHaveBeenCalled();
     });
 
-    it('should NOT add tracked skill to .gitignore', async () => {
+    it('should NOT modify .gitignore for tracked skills', async () => {
       const config: SkillInjectionConfig = {
         enabled: true,
         skills: [
@@ -409,56 +409,19 @@ describe('SkillInjectorService', () => {
         const path = String(p);
         if (path.includes('SKILL.md')) throw new Error('ENOENT');
       });
-
-      // git ls-files: tracked (returns 0)
+      // git ls-files: tracked
       mockExecFile.mockResolvedValue({
         stdout: '.claude/skills/tracked-skill/SKILL.md',
         stderr: '',
       });
-
       mockReadFile.mockResolvedValue('');
 
       await service.inject(worktreePath, config, repoRoot);
 
-      // writeFile should not include tracked-skill
-      if (mockWriteFile.mock.calls.length > 0) {
-        const written = String(mockWriteFile.mock.calls[0][1]);
-        expect(written).not.toContain('.claude/skills/tracked-skill/');
-      }
+      expect(mockWriteFile).not.toHaveBeenCalled();
     });
 
-    it('should not create duplicate .gitignore entries on repeated runs', async () => {
-      const config: SkillInjectionConfig = {
-        enabled: true,
-        skills: [
-          {
-            name: 'skill-x',
-            type: SkillSourceType.Local,
-            source: '.claude/skills/skill-x',
-          },
-        ],
-      };
-
-      mockAccess.mockImplementation(async (p) => {
-        const path = String(p);
-        if (path.includes('SKILL.md')) throw new Error('ENOENT');
-      });
-      mockExecFile.mockRejectedValue(new Error('not tracked'));
-
-      // .gitignore already contains the entry
-      mockReadFile.mockResolvedValue('node_modules/\n.claude/skills/skill-x/\n');
-
-      await service.inject(worktreePath, config, repoRoot);
-
-      // Should not write a duplicate entry
-      if (mockWriteFile.mock.calls.length > 0) {
-        const written = String(mockWriteFile.mock.calls[0][1]);
-        const matches = written.match(/\.claude\/skills\/skill-x\//g);
-        expect(matches?.length ?? 0).toBeLessThanOrEqual(1);
-      }
-    });
-
-    it('should create .gitignore when absent', async () => {
+    it('should NOT create .gitignore when absent', async () => {
       const config: SkillInjectionConfig = {
         enabled: true,
         skills: [
@@ -475,16 +438,36 @@ describe('SkillInjectorService', () => {
         if (path.includes('SKILL.md')) throw new Error('ENOENT');
       });
       mockExecFile.mockRejectedValue(new Error('not tracked'));
-
-      // .gitignore does not exist
       mockReadFile.mockRejectedValue(new Error('ENOENT'));
 
-      await service.inject(worktreePath, config, repoRoot);
+      const result = await service.inject(worktreePath, config, repoRoot);
 
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('.gitignore'),
-        expect.stringContaining('.claude/skills/fresh-skill/')
-      );
+      expect(result.injected).toContain('fresh-skill');
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should NOT modify .gitignore when all skills are already present (skipped)', async () => {
+      const config: SkillInjectionConfig = {
+        enabled: true,
+        skills: [
+          {
+            name: 'existing-skill',
+            type: SkillSourceType.Local,
+            source: '.claude/skills/existing-skill',
+          },
+        ],
+      };
+
+      // SKILL.md exists — access succeeds
+      mockAccess.mockResolvedValue(undefined);
+      // git ls-files: untracked — old code wrote entries even for skipped skills
+      mockExecFile.mockRejectedValue(new Error('not tracked'));
+      mockReadFile.mockResolvedValue('');
+
+      const result = await service.inject(worktreePath, config, repoRoot);
+
+      expect(result.skipped).toContain('existing-skill');
+      expect(mockWriteFile).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## What

Injected skills (`.claude/skills/`) no longer leak into Merge Review commits. They are excluded at **staging time** on every commit surface, instead of via `.gitignore` entries:

- `SkillInjectorService` no longer writes to the worktree's tracked `.gitignore` (`updateGitignore` + `isTrackedInGit` removed) — injection now produces zero tracked-file diff
- `GitCommitService.stageAndCommit` unstages newly-added files under `.claude/skills/` right after `git add -A` (only `--diff-filter=A`, so edits to skills already tracked in the repo stay committable; best-effort — never blocks an ordinary commit)
- Both merge-node agent prompts (commit-push-pr and CI-watch-fix) now instruct `git reset -- .claude/skills/` alongside the existing `specs/` exclusion, plus a Constraints line

## Why

Bug: fresh feature worktrees showed injected-skill noise in the Merge Review diff, and skill files could end up in feature commits. Two leak paths, one root cause — the injector appended ignore entries to a **tracked** `.gitignore`, so every fresh worktree carried an uncommitted `.gitignore` diff that the prompt's `git add -A` staged into the Merge Review commit; untracked skill files were swept up by the same `git add -A`. `.gitignore` cannot fix this (writing to it is itself the diff), so the exclusion moved to staging time, mirroring the `specs/` convention.

## Screenshots / Recording

N/A — non-UI change.

## Testing

- `pnpm vitest run` on the changed areas — 209 unit tests across git-commit, skill-injector, and merge-prompts suites (incl. the pr-target prompt suite), all green
- New real-git integration test `git-commit.service.skills-exclusion.test.ts` — injected skill never committed; tracked-skill edit committed; skills-only worktree skips the commit (2/2)
- `pnpm typecheck` — clean
- New unit suites pin the staging mechanics: call ordering (`add` → enumerate → `reset` → `commit`), tracked-edit preservation, enumeration-failure fallback, never blocking ordinary commits; injector `.gitignore` non-interference (zero reads/writes)
- `pnpm test:unit` — 10,577 / 10,578 passed; the single failure is `contributor-onboarding-registrations.test.ts > resolves IDiagnosticRunner as DiagnosticRunner`, a ~30s test that hit its 60s timeout under a heavily loaded local run — verified green in isolation, unrelated to this change (DI layer)

## Checklist

- [ ] `pnpm lint` passes — full-repo run OOMs on this 3.6GB-RAM local machine (Node heap limit, no lint errors reported); the 9 changed files pass `eslint --max-warnings 0` (verified standalone + via pre-commit hook); CI will confirm
- [x] `pnpm typecheck` passes
- [ ] `pnpm test:unit` and `pnpm test:int` pass — unit green except one load-induced timeout in an unrelated DI test (passes in isolation); new integration test 2/2; CI will authoritatively confirm
- [ ] `pnpm build` succeeds (CI will verify; typecheck + hooks already green)
