### PR TITLE
fix(agents): honour SupervisorPolicy.enabled when evaluating gates

### DIFF
--- a/packages/core/src/application/use-cases/agents/evaluate-supervisor-decision.use-case.ts
+++ b/packages/core/src/application/use-cases/agents/evaluate-supervisor-decision.use-case.ts
@@ -62,7 +62,7 @@ export interface EvaluateSupervisorDecisionResult {
    * Diagnostic reason returned when `evaluated` is false. Stable string
    * so the caller can branch deterministically.
    */
-  skippedReason?: 'flag-off' | 'no-policy' | 'supervisor-failed';
+  skippedReason?: 'flag-off' | 'no-policy' | 'disabled' | 'supervisor-failed';
   /**
    * Populated when the underlying evaluator threw or timed out (FR-22). The
    * use case absorbs the error so the caller is never crashed by a
@@ -103,6 +103,15 @@ export class EvaluateSupervisorDecisionUseCase {
     });
     if (!policy) {
       return { evaluated: false, skippedReason: 'no-policy' };
+    }
+    // A disabled policy is inert: `shep supervisor disable` flips this flag,
+    // and `shep supervisor status` reports it, so honouring it here is what
+    // makes the command mean anything. Previously the flag was written,
+    // displayed and even echoed into the evaluator prompt, but never read —
+    // an `autonomous` policy kept evaluating and auto-closing gates after it
+    // had been disabled.
+    if (!policy.enabled) {
+      return { evaluated: false, skippedReason: 'disabled' };
     }
 
     const now = new Date();

--- a/tests/unit/application/use-cases/agents/evaluate-supervisor-decision.use-case.test.ts
+++ b/tests/unit/application/use-cases/agents/evaluate-supervisor-decision.use-case.test.ts
@@ -16,6 +16,8 @@ import { EvaluateSupervisorDecisionUseCase } from '@/application/use-cases/agent
 import type { EscalateToUserUseCase } from '@/application/use-cases/agents/escalate-to-user.use-case.js';
 import { GetSupervisorPolicyUseCase } from '@/application/use-cases/agents/get-supervisor-policy.use-case.js';
 import { ConfigureSupervisorUseCase } from '@/application/use-cases/agents/configure-supervisor.use-case.js';
+import { DisableSupervisorUseCase } from '@/application/use-cases/agents/disable-supervisor.use-case.js';
+import { EnableSupervisorUseCase } from '@/application/use-cases/agents/enable-supervisor.use-case.js';
 import { InMemorySupervisorPolicyRepository } from '@/infrastructure/adapters/in-memory/in-memory-supervisor-policy-repository.js';
 import { InMemorySupervisorDecisionRepository } from '@/infrastructure/adapters/in-memory/in-memory-supervisor-decision-repository.js';
 import { InMemorySupervisorAgent } from '@/infrastructure/adapters/in-memory/in-memory-supervisor-agent.js';
@@ -130,6 +132,53 @@ describe('EvaluateSupervisorDecisionUseCase', () => {
     expect(result.skippedReason).toBe('no-policy');
     expect(result.decision).toBeUndefined();
     expect(activityLog.entries).toHaveLength(0);
+  });
+
+  // `shep supervisor disable` writes this flag and `shep supervisor status`
+  // prints it. Before this guard the flag was never read, so a disabled
+  // `autonomous` policy carried on evaluating gates and closing them.
+  it('returns evaluated=false with skippedReason="disabled" when the policy is disabled', async () => {
+    await configure.execute({
+      scopeType: SupervisorScopeType.app,
+      scopeId: 'app-1',
+      autonomyLevel: SupervisorAutonomy.autonomous,
+    });
+    await new DisableSupervisorUseCase(policyRepo).execute({
+      scopeType: SupervisorScopeType.app,
+      scopeId: 'app-1',
+    });
+
+    const useCase = makeUseCase(true);
+    const result = await useCase.execute({
+      event: gateEvent(),
+      supervisorRunId: 'sup-run-1',
+    });
+
+    expect(result.evaluated).toBe(false);
+    expect(result.skippedReason).toBe('disabled');
+    expect(result.decision).toBeUndefined();
+    expect(activityLog.entries).toHaveLength(0);
+  });
+
+  it('evaluates again once the policy is re-enabled', async () => {
+    await configure.execute({
+      scopeType: SupervisorScopeType.app,
+      scopeId: 'app-1',
+      autonomyLevel: SupervisorAutonomy.autonomous,
+    });
+    const disable = new DisableSupervisorUseCase(policyRepo);
+    const enable = new EnableSupervisorUseCase(policyRepo);
+    await disable.execute({ scopeType: SupervisorScopeType.app, scopeId: 'app-1' });
+    await enable.execute({ scopeType: SupervisorScopeType.app, scopeId: 'app-1' });
+
+    const useCase = makeUseCase(true);
+    const result = await useCase.execute({
+      event: gateEvent(),
+      supervisorRunId: 'sup-run-1',
+    });
+
+    expect(result.evaluated).toBe(true);
+    expect(result.decision).toBeDefined();
   });
 
   it('persists a SupervisorDecision and mirrors to activity_log on the happy path', async () => {


### PR DESCRIPTION
## What

`EvaluateSupervisorDecisionUseCase` now honours `SupervisorPolicy.enabled`. A disabled policy short-circuits with a new `disabled` skipped reason, mirroring the existing `flag-off` and `no-policy` guards.

## Why

`shep supervisor disable` was a no-op for evaluation.

- `DisableSupervisorUseCase` writes `enabled = false`.
- `shep supervisor status` prints `enabled  no`.
- `evaluator-prompt.ts` echoes `enabled: false` to the model.

…and nothing in the evaluation path ever read the flag. I checked every reader: the SQLite repository's `findByScope` / `findByScopeAndFeature` do not filter on it, `GetSupervisorPolicyUseCase` does not filter on it, and `EvaluateSupervisorDecisionUseCase` did not check it. The only consumers were the mapper, the prompt, and the status command.

The user-visible consequence: a user who ran `shep supervisor disable` on a policy at `autonomous` autonomy still had the supervisor evaluating every approval gate and still had it closing them through `ApproveAgentRunUseCase` with `actor = supervisor:<id>`. Disabling looked like it worked — status said `no` — but behaviour was unchanged.

The audit trail was wrong too: `supervisor_decisions` and `activity_log` kept accumulating decisions attributed to a supervisor the user believed was off.

## Screenshots / Recording

N/A — non-UI change.

## Testing

| Command | Result |
| --- | --- |
| `pnpm lint` | clean |
| `pnpm typecheck` | clean |
| `pnpm format:check` | clean |
| Supervisor, agent and feature-agent suites | 1,073 passing, 11 failing — see below |

Two new tests in `tests/unit/application/use-cases/agents/evaluate-supervisor-decision.use-case.test.ts`:

1. **disabled → `evaluated: false`, `skippedReason: 'disabled'`, no decision row, empty activity log.** The test drives the real `DisableSupervisorUseCase` rather than poking the repository, so it exercises the path a user actually takes.
2. **re-enabling restores evaluation** — guards against the fix over-blocking.

I confirmed test 1 fails without the production change (reverting the guard leaves `evaluated: true`), so it is a real regression guard rather than decoration.

**The 11 failures are pre-existing and environmental**, not related to this change: `EPERM: mkdir '<home>/.shep/logs'` in `feature-agent-process.service.test.ts`. That file builds its log directory from `join(homedir(), '.shep', 'logs')` and so ignores `SHEP_HOME`; it fails identically on unmodified `main` in my environment.

## Scope

I deliberately kept this to the enforcement gap. Two related observations I did **not** change, since they are behaviour questions rather than bugs:

- The guard runs after the `collaboration` flag check but before policy resolution ordering could matter — a disabled policy and a missing policy now produce different `skippedReason` values. If you would rather callers not distinguish them, say so and I will collapse them.
- `enabled` is not filtered in the repository queries themselves. Filtering there would be cheaper (no row fetch), but it would make `listByScope` disagree with `findByScope` for the settings UI, so I kept the check at the point of use.
